### PR TITLE
Renaming of datasets

### DIFF
--- a/ccic/bin/process.py
+++ b/ccic/bin/process.py
@@ -42,7 +42,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "input_type",
-        metavar="GPMIR/GRIDSAT",
+        metavar="CPCIR/GRIDSAT",
         type=str,
         help="For which type of input to run the retrieval.",
     )
@@ -284,7 +284,7 @@ def run(args):
         args: The namespace object provided by the top-level parser.
     """
     from ccic.data.gridsat import GridSatB1
-    from ccic.data.gpmir import GPMIR
+    from ccic.data.cpcir import CPCIR
     from ccic.processing import (
         process_input_file,
         get_input_files,
@@ -300,13 +300,13 @@ def run(args):
 
     # Determine input data.
     input_type = args.input_type.lower()
-    if not input_type in ["gpmir", "gridsatb1"]:
+    if not input_type in ["cpcir", "gridsatb1"]:
         LOGGER.error(
-            "'input_type' must be one of ['gpmir', gridsatb1'] not '%s'.", input_type
+            "'input_type' must be one of ['cpcir', gridsatb1'] not '%s'.", input_type
         )
         return 1
-    if input_type == "gpmir":
-        input_cls = GPMIR
+    if input_type == "cpcir":
+        input_cls = CPCIR
     else:
         input_cls = GridSatB1
 

--- a/ccic/bin/process.py
+++ b/ccic/bin/process.py
@@ -42,7 +42,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "input_type",
-        metavar="CPCIR/GRIDSAT",
+        metavar="cpcir/gridsat",
         type=str,
         help="For which type of input to run the retrieval.",
     )
@@ -283,7 +283,7 @@ def run(args):
     Args:
         args: The namespace object provided by the top-level parser.
     """
-    from ccic.data.gridsat import GridSatB1
+    from ccic.data.gridsat import GridSat
     from ccic.data.cpcir import CPCIR
     from ccic.processing import (
         process_input_file,
@@ -300,15 +300,15 @@ def run(args):
 
     # Determine input data.
     input_type = args.input_type.lower()
-    if not input_type in ["cpcir", "gridsatb1"]:
+    if not input_type in ["cpcir", "gridsat"]:
         LOGGER.error(
-            "'input_type' must be one of ['cpcir', gridsatb1'] not '%s'.", input_type
+            "'input_type' must be one of ['cpcir', gridsat'] not '%s'.", input_type
         )
         return 1
     if input_type == "cpcir":
         input_cls = CPCIR
     else:
-        input_cls = GridSatB1
+        input_cls = GridSat
 
     # Output path
     output = Path(args.output)

--- a/ccic/data/__init__.py
+++ b/ccic/data/__init__.py
@@ -11,7 +11,7 @@ import xarray as xr
 
 from ccic.data.cloudsat import CloudSat2CIce, CloudSat2BCLDCLASS
 from ccic.data.cpcir import CPCIR
-from ccic.data.gridsat import GridSatB1
+from ccic.data.gridsat import GridSat
 
 
 class DownloadCache:
@@ -96,13 +96,13 @@ def process_cloudsat_files(
             timedelta=timedelta,
             subsample=True
         )
-    gridsat_files = GridSatB1.provider.get_files_in_range(
+    gridsat_files = GridSat.provider.get_files_in_range(
         to_datetime(start_time),
         to_datetime(end_time),
         start_inclusive=True
     )
     for filename in gridsat_files:
-        gs_file = cache.get(GridSatB1, filename).result()
+        gs_file = cache.get(GridSat, filename).result()
         scenes += gs_file.get_matches(
             rng,
             cloudsat_files,

--- a/ccic/data/__init__.py
+++ b/ccic/data/__init__.py
@@ -10,7 +10,7 @@ from pansat.time import to_datetime
 import xarray as xr
 
 from ccic.data.cloudsat import CloudSat2CIce, CloudSat2BCLDCLASS
-from ccic.data.gpmir import GPMIR
+from ccic.data.cpcir import CPCIR
 from ccic.data.gridsat import GridSatB1
 
 
@@ -48,13 +48,13 @@ def process_cloudsat_files(
         timedelta=15,
 ):
     """
-    Match CloudSat product files for a given granule with GPMIR and
+    Match CloudSat product files for a given granule with CPCIR and
     GridSat B1 observations.
 
     Args:
         cloudsat_files: A list of the CloudSat file objects to match
-            with the GPMIR and GridSat data.
-        cache: A download cache to use for the GPMIR and GridSat files.
+            with the CPCIR and GridSat data.
+        cache: A download cache to use for the CPCIR and GridSat files.
         size: The size of the match-up scenes to extract.
         timedelta: The maximum time difference to allow between CloudSat
             and geostationary observations.
@@ -75,21 +75,21 @@ def process_cloudsat_files(
 
     scenes = []
 
-    gpmir_files = GPMIR.provider.get_files_in_range(
+    cpcir_files = CPCIR.provider.get_files_in_range(
         to_datetime(start_time),
         to_datetime(end_time),
         start_inclusive=True
     )
     cloudsat_files = [cs_file.result() for cs_file in cloudsat_files]
-    for filename in gpmir_files:
-        gpmir_file = cache.get(GPMIR, filename).result()
-        scenes += gpmir_file.get_matches(
+    for filename in cpcir_files:
+        cpcir_file = cache.get(CPCIR, filename).result()
+        scenes += cpcir_file.get_matches(
             rng,
             cloudsat_files,
             size=size,
             timedelta=timedelta
         )
-        scenes += gpmir_file.get_matches(
+        scenes += cpcir_file.get_matches(
             rng,
             cloudsat_files,
             size=size,

--- a/ccic/data/cpcir.py
+++ b/ccic/data/cpcir.py
@@ -1,8 +1,8 @@
 """
-ccic.data.gpmir
+ccic.data.cpcir
 ===============
 
-This module provides classes to read the GPM merged IR observations.
+This module provides classes to read the NCEP/CPC 4-km IR data.
 """
 from datetime import datetime
 import logging
@@ -20,22 +20,22 @@ from ccic.data import cloudsat
 from ccic.data.utils import included_pixel_mask, extract_roi
 
 PROVIDER = Disc2Provider(gpm_mergeir)
-GPMIR_GRID = create_area_def(
-    "gpmir_area",
+CPCIR_GRID = create_area_def(
+    "cpcir_area",
     {"proj": "longlat", "datum": "WGS84"},
     area_extent=[-180.0, -60.0, 180.0, 60.0],
     resolution= (0.03637833468067906, 0.036385688295936934),
     units="degrees",
-    description="GPMIR grid",
+    description="CPCIR grid",
 )
 
 
 def subsample_dataset(dataset):
     """
-    Subsamples GPMIR dataset by a factor of two.
+    Subsamples CPCIR dataset by a factor of two.
 
     Args:
-        dataset: The content of the GPMIR file as xarray.Dataset
+        dataset: The content of the CPCIR file as xarray.Dataset
 
     Return:
         The subsampled dataset.
@@ -77,25 +77,24 @@ def subsample_dataset(dataset):
     return dataset_new
 
 
-class GPMIR:
+class CPCIR:
     """
-    Interface class to access GPM IR data.
+    Interface class to access NCEP/CPC 4-km IR data.
     """
-
     provider = PROVIDER
 
     @classmethod
     def find_files(cls, path, start_time=None, end_time=None):
         """
-        Find GPMIR files in folder.
+        Find CPCIR files in folder.
 
         Args:
-            path: Path to the folder in which to look for GPMIR files.
+            path: Path to the folder in which to look for CPCIR files.
             start_time: Optional start time to filter returned files.
             end_time: Optional end time to filter returned files.
 
         Return:
-            A list containing the found GPMIR files that match the
+            A list containing the found CPCIR files that match the
             time constraints given by 'start_time' and 'end_time'
 
         """
@@ -257,11 +256,11 @@ class GPMIR:
         data = self.to_xarray_dataset()
         if subsample:
             data = subsample_dataset(data)
-            source = "GPMIR2"
-            grid = GPMIR_GRID[::2, ::2]
+            source = "CPCIR2"
+            grid = CPCIR_GRID[::2, ::2]
         else:
-            source = "GPMIR"
-            grid = GPMIR_GRID
+            source = "CPCIR"
+            grid = CPCIR_GRID
 
         new_names = {"Tb": "ir_win", "lat": "latitude", "lon": "longitude"}
         data = data[["Tb", "time"]].rename(new_names)
@@ -330,7 +329,7 @@ class GPMIR:
                 if not np.any(included):
                     logger.warning(
                         "Found an empty sample when extracting scenes from "
-                        "GPM IR file '%s'.", self
+                        "CPC IR file '%s'.", self
                     )
                     break
                 indices = (indices[0][~included], indices[1][~included])

--- a/ccic/data/gridsat.py
+++ b/ccic/data/gridsat.py
@@ -3,7 +3,7 @@ ccic.data.gridsat
 =================
 
 This module provides classes to represent and handle the NOAA
-GridSat-B1 files.
+GridSat files.
 """
 from datetime import datetime
 import logging
@@ -27,11 +27,11 @@ GRIDSAT_GRID = create_area_def(
     area_extent=[-180.035, -70.035, 179.975, 69.965],
     resolution=0.07,
     units="degrees",
-    description="GridSat-B1 grid.",
+    description="GridSat grid.",
 )
 
 
-class GridSatB1:
+class GridSat:
     """
     Interface to download an read GridSat B1 files.
     """

--- a/ccic/data/gridsat.py
+++ b/ccic/data/gridsat.py
@@ -44,7 +44,7 @@ class GridSatB1:
         Find GridSat files in folder.
 
         Args:
-            path: Path to the folder in which to look for GPMIR files.
+            path: Path to the folder in which to look for GridSat files.
             start_time: Optional start time to filter returned files.
             end_time: Optional end time to filter returned files.
 
@@ -249,7 +249,7 @@ class GridSatB1:
             if not np.any(included):
                 logger.warning(
                     "Found an empty sample when extracting scenes from "
-                    "GPM IR file '%s'.", self
+                    "CPC IR file '%s'.", self
                 )
                 break
             indices = (indices[0][~included], indices[1][~included])

--- a/ccic/processing.py
+++ b/ccic/processing.py
@@ -22,7 +22,7 @@ import zarr
 
 from ccic import __version__
 from ccic.tiler import Tiler
-from ccic.data.gpmir import GPMIR
+from ccic.data.cpcir import CPCIR
 from ccic.data.gridsat import GridSatB1
 from ccic.data.utils import extract_roi
 from ccic.codecs import LogBins
@@ -367,13 +367,13 @@ def get_output_filename(input_file, date, retrieval_settings):
     Return:
         A string containing the filename.
     """
-    if isinstance(input_file, GPMIR):
-        file_type = "gpmir"
+    if isinstance(input_file, CPCIR):
+        file_type = "cpcir"
     elif isinstance(input_file, GridSatB1):
         file_type = "gridsat"
     else:
         raise ValueError(
-            "'input_file' should be an instance of 'GPMIR' or " "'GridSatB1' not '%s'.",
+            "'input_file' should be an instance of 'CPCIR' or " "'GridSatB1' not '%s'.",
             type(input_file),
         )
     date_str = to_datetime(date).strftime("%Y%m%d%H%M")

--- a/ccic/processing.py
+++ b/ccic/processing.py
@@ -23,7 +23,7 @@ import zarr
 from ccic import __version__
 from ccic.tiler import Tiler
 from ccic.data.cpcir import CPCIR
-from ccic.data.gridsat import GridSatB1
+from ccic.data.gridsat import GridSat
 from ccic.data.utils import extract_roi
 from ccic.codecs import LogBins
 
@@ -369,11 +369,11 @@ def get_output_filename(input_file, date, retrieval_settings):
     """
     if isinstance(input_file, CPCIR):
         file_type = "cpcir"
-    elif isinstance(input_file, GridSatB1):
+    elif isinstance(input_file, GridSat):
         file_type = "gridsat"
     else:
         raise ValueError(
-            "'input_file' should be an instance of 'CPCIR' or " "'GridSatB1' not '%s'.",
+            "'input_file' should be an instance of 'CPCIR' or " "'GridSat' not '%s'.",
             type(input_file),
         )
     date_str = to_datetime(date).strftime("%Y%m%d%H%M")

--- a/test/data/test_gridsat.py
+++ b/test/data/test_gridsat.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from ccic.data.cloudsat import CloudSat2CIce, CloudSat2BCLDCLASS
-from ccic.data.gridsat import GridSatB1
+from ccic.data.gridsat import GridSat
 
 
 TEST_DATA = os.environ.get("CCIC_TEST_DATA", None)
@@ -26,18 +26,18 @@ def test_find_files():
     """
     Ensure that all three files in test data folder are found.
     """
-    files = GridSatB1.find_files(TEST_DATA)
+    files = GridSat.find_files(TEST_DATA)
     assert len(files) == 3
 
     start_time = "2008-02-01T01:00:00"
-    files = GridSatB1.find_files(TEST_DATA, start_time=start_time)
+    files = GridSat.find_files(TEST_DATA, start_time=start_time)
     assert len(files) == 1
 
     end_time = "2008-02-01T01:00:00"
-    files = GridSatB1.find_files(TEST_DATA, end_time=end_time)
+    files = GridSat.find_files(TEST_DATA, end_time=end_time)
     assert len(files) == 2
 
-    files = GridSatB1.find_files(TEST_DATA, start_time=start_time, end_time=end_time)
+    files = GridSat.find_files(TEST_DATA, start_time=start_time, end_time=end_time)
     assert len(files) == 0
 
 
@@ -46,11 +46,11 @@ def test_get_times():
     Assert that the correct time are returned for a given day.
     """
     start_time = "2016-01-01T00:00:00"
-    times = GridSatB1.get_available_files(start_time)
+    times = GridSat.get_available_files(start_time)
     assert len(times) == 8
 
     end_time = "2016-01-01T11:59:00"
-    times = GridSatB1.get_available_files(
+    times = GridSat.get_available_files(
         start_time=start_time,
         end_time=end_time
     )
@@ -62,7 +62,7 @@ def test_get_input_file_attributes():
     """
     Assert that data is loaded with decreasing latitudes.
     """
-    input_file = GridSatB1(TEST_DATA / GRIDSAT_FILE)
+    input_file = GridSat(TEST_DATA / GRIDSAT_FILE)
     attrs = input_file.get_input_file_attributes()
     assert isinstance(attrs, dict)
 
@@ -71,7 +71,7 @@ def test_get_retrieval_input():
     """
     Assert that data is loaded with decreasing latitudes.
     """
-    input_file = GridSatB1(TEST_DATA / GRIDSAT_FILE)
+    input_file = GridSat(TEST_DATA / GRIDSAT_FILE)
     x = input_file.get_retrieval_input()
     assert x.ndim == 4
     assert x.shape[0] == 1
@@ -91,7 +91,7 @@ def test_to_xarray_dataset():
     """
     Assert that data is loaded with decreasing latitudes.
     """
-    gridsat = GridSatB1(TEST_DATA / GRIDSAT_FILE)
+    gridsat = GridSat(TEST_DATA / GRIDSAT_FILE)
     data = gridsat.to_xarray_dataset()
     assert (np.diff(data.lat.data) < 0.0).all()
 
@@ -102,7 +102,7 @@ def test_matches():
     Make sure that matches are found for files that overlap in time.
     """
     rng = np.random.default_rng(111)
-    gridsat = GridSatB1(TEST_DATA / GRIDSAT_FILE)
+    gridsat = GridSat(TEST_DATA / GRIDSAT_FILE)
     cloudsat_files = [
         CloudSat2CIce(TEST_DATA / CS_2CICE_FILE),
         CloudSat2BCLDCLASS(TEST_DATA / CS_2BCLDCLASS_FILE),

--- a/test/data/test_utils.py
+++ b/test/data/test_utils.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from ccic.data.gpmir import GPMIR
+from ccic.data.cpcir import CPCIR
 from ccic.data.utils import extract_roi, included_pixel_mask
 
 TEST_DATA = os.environ.get("CCIC_TEST_DATA", None)
@@ -16,7 +16,7 @@ if TEST_DATA is not None:
 NEEDS_TEST_DATA = pytest.mark.skipif(
     TEST_DATA is None, reason="Needs 'CCIC_TEST_DATA'."
 )
-GPMIR_FILE = "merg_2008020101_4km-pixel.nc4"
+CPCIR_FILE = "merg_2008020101_4km-pixel.nc4"
 
 @NEEDS_TEST_DATA
 def test_extract_roi():
@@ -25,16 +25,16 @@ def test_extract_roi():
     and area with the coordinates within the expected limits and ensures
     the min_size option return correctly sized region.
     """
-    gpmir_file = GPMIR(TEST_DATA / GPMIR_FILE)
-    gpmir_data = gpmir_file.to_xarray_dataset()
+    cpcir_file = CPCIR(TEST_DATA / CPCIR_FILE)
+    cpcir_data = cpcir_file.to_xarray_dataset()
 
-    data_roi = extract_roi(gpmir_data, (-10, -10, 10, 10))
+    data_roi = extract_roi(cpcir_data, (-10, -10, 10, 10))
     assert (data_roi.lat.data >= -10).all()
     assert (data_roi.lat.data <= 10).all()
     assert (data_roi.lon.data >= -10).all()
     assert (data_roi.lon.data <= 10).all()
 
-    data_roi = extract_roi(gpmir_data, (-1, -1, 1, 1), min_size=256)
+    data_roi = extract_roi(cpcir_data, (-1, -1, 1, 1), min_size=256)
     assert data_roi.lat.size == 256
     assert data_roi.lon.size == 256
 

--- a/test/test_processing.py
+++ b/test/test_processing.py
@@ -14,7 +14,7 @@ import numpy as np
 import xarray as xr
 
 from ccic.data.cpcir import CPCIR
-from ccic.data.gridsat import GridSatB1
+from ccic.data.gridsat import GridSat
 from ccic.processing import (
     get_input_files,
     RemoteFile,
@@ -76,13 +76,13 @@ def test_get_input_files():
     #
 
     input_files = get_input_files(
-        GridSatB1,
+        GridSat,
         start_time="2008-02-01T00:00:00"
     )
     assert len(input_files) == 1
     assert isinstance(input_files[0], RemoteFile)
     input_files = get_input_files(
-        GridSatB1,
+        GridSat,
         start_time="2008-02-01T00:00:00",
         end_time="2008-02-01T23:59:00"
     )
@@ -90,21 +90,21 @@ def test_get_input_files():
     assert isinstance(input_files[0], RemoteFile)
 
     input_files = get_input_files(
-        GridSatB1,
+        GridSat,
         start_time="2008-02-01T00:00:00",
         path=TEST_DATA
     )
     assert len(input_files) == 2
-    assert isinstance(input_files[0], GridSatB1)
+    assert isinstance(input_files[0], GridSat)
 
     input_files = get_input_files(
-        GridSatB1,
+        GridSat,
         start_time="2008-02-01T00:00:00",
         end_time="2008-02-02T00:00:00",
         path=TEST_DATA
     )
     assert len(input_files) == 3
-    assert isinstance(input_files[0], GridSatB1)
+    assert isinstance(input_files[0], GridSat)
 
 
 def test_remote_file():
@@ -137,7 +137,7 @@ def test_processing(tmp_path):
     """
     mrnn = MRNN.load(TEST_DATA / "models" / "ccic.pckl")
     cpcir_file = CPCIR(TEST_DATA / "input_data" / "merg_2008020100_4km-pixel.nc4")
-    gridsat_file = GridSatB1(TEST_DATA / "input_data" / "GRIDSAT-B1.2008.02.01.00.v02r01.nc")
+    gridsat_file = GridSat(TEST_DATA / "input_data" / "GRIDSAT-B1.2008.02.01.00.v02r01.nc")
 
     for input_file in [cpcir_file, gridsat_file]:
         results = process_input_file(mrnn, input_file)
@@ -258,7 +258,7 @@ def test_invalid_mask():
     """
     mrnn = MRNN.load(TEST_DATA / "models" / "ccic.pckl")
     cpcir_file = CPCIR(TEST_DATA / "input_data" / "merg_2008020100_4km-pixel.nc4")
-    gridsat_file = GridSatB1(TEST_DATA / "input_data" / "GRIDSAT-B1.2008.02.01.00.v02r01.nc")
+    gridsat_file = GridSat(TEST_DATA / "input_data" / "GRIDSAT-B1.2008.02.01.00.v02r01.nc")
 
     for input_file in [cpcir_file, gridsat_file]:
         x = input_file.get_retrieval_input()

--- a/test/test_processing.py
+++ b/test/test_processing.py
@@ -13,7 +13,7 @@ from quantnn.mrnn import MRNN
 import numpy as np
 import xarray as xr
 
-from ccic.data.gpmir import GPMIR
+from ccic.data.cpcir import CPCIR
 from ccic.data.gridsat import GridSatB1
 from ccic.processing import (
     get_input_files,
@@ -37,17 +37,17 @@ def test_get_input_files():
     """
 
     #
-    # GPMIR
+    # CPCIR
     #
 
     input_files = get_input_files(
-        GPMIR,
+        CPCIR,
         start_time="2008-02-01T00:00:00"
     )
     assert len(input_files) == 1
     assert isinstance(input_files[0], RemoteFile)
     input_files = get_input_files(
-        GPMIR,
+        CPCIR,
         start_time="2008-02-01T00:00:00",
         end_time="2008-02-01T23:59:00"
     )
@@ -55,21 +55,21 @@ def test_get_input_files():
     assert isinstance(input_files[0], RemoteFile)
 
     input_files = get_input_files(
-        GPMIR,
+        CPCIR,
         start_time="2008-02-01T00:00:00",
         path=TEST_DATA
     )
     assert len(input_files) == 2
-    assert isinstance(input_files[0], GPMIR)
+    assert isinstance(input_files[0], CPCIR)
 
     input_files = get_input_files(
-        GPMIR,
+        CPCIR,
         start_time="2008-02-01T00:00:00",
         end_time="2008-02-02T00:00:00",
         path=TEST_DATA
     )
     assert len(input_files) == 4
-    assert isinstance(input_files[0], GPMIR)
+    assert isinstance(input_files[0], CPCIR)
 
     #
     # GridSat
@@ -116,12 +116,12 @@ def test_remote_file():
 
     pool = ThreadPoolExecutor(max_workers=4)
     input_files_no_prefetch = get_input_files(
-        GPMIR,
+        CPCIR,
         start_time="2008-02-01T00:00:00",
         working_dir=temp_dir_1.name
     )
     input_files_prefetch = get_input_files(
-        GPMIR,
+        CPCIR,
         start_time="2008-02-02T00:00:00",
         thread_pool=pool,
         working_dir=temp_dir_2.name
@@ -133,13 +133,13 @@ def test_remote_file():
 
 def test_processing(tmp_path):
     """
-    Test processing and writing of GPMIR and GridSat input files.
+    Test processing and writing of CPCIR and GridSat input files.
     """
     mrnn = MRNN.load(TEST_DATA / "models" / "ccic.pckl")
-    gpmir_file = GPMIR(TEST_DATA / "input_data" / "merg_2008020100_4km-pixel.nc4")
+    cpcir_file = CPCIR(TEST_DATA / "input_data" / "merg_2008020100_4km-pixel.nc4")
     gridsat_file = GridSatB1(TEST_DATA / "input_data" / "GRIDSAT-B1.2008.02.01.00.v02r01.nc")
 
-    for input_file in [gpmir_file, gridsat_file]:
+    for input_file in [cpcir_file, gridsat_file]:
         results = process_input_file(mrnn, input_file)
         assert "tiwp" in results
         assert "tiwp_log_std_dev" in results
@@ -192,15 +192,15 @@ def test_get_output_filename():
     """
     Ensure that filenames have the right suffixes.
     """
-    gpmir_file = GPMIR(TEST_DATA / "input_data" / "merg_2008020100_4km-pixel.nc4")
-    data = gpmir_file.to_xarray_dataset()
+    cpcir_file = CPCIR(TEST_DATA / "input_data" / "merg_2008020100_4km-pixel.nc4")
+    data = cpcir_file.to_xarray_dataset()
     retrieval_settings = RetrievalSettings()
     retrieval_settings.output_format = OutputFormat["NETCDF"]
-    output_filename_netcdf = get_output_filename(gpmir_file, data.time[0].item(), retrieval_settings)
+    output_filename_netcdf = get_output_filename(cpcir_file, data.time[0].item(), retrieval_settings)
     assert Path(output_filename_netcdf).suffix == ".nc"
 
     retrieval_settings.output_format = OutputFormat["ZARR"]
-    output_filename_zarr = get_output_filename(gpmir_file, data.time[0].item(), retrieval_settings)
+    output_filename_zarr = get_output_filename(cpcir_file, data.time[0].item(), retrieval_settings)
     assert Path(output_filename_zarr).suffix == ".zarr"
 
     assert output_filename_netcdf != output_filename_zarr
@@ -257,10 +257,10 @@ def test_invalid_mask():
     Test masking of invalid inputs.
     """
     mrnn = MRNN.load(TEST_DATA / "models" / "ccic.pckl")
-    gpmir_file = GPMIR(TEST_DATA / "input_data" / "merg_2008020100_4km-pixel.nc4")
+    cpcir_file = CPCIR(TEST_DATA / "input_data" / "merg_2008020100_4km-pixel.nc4")
     gridsat_file = GridSatB1(TEST_DATA / "input_data" / "GRIDSAT-B1.2008.02.01.00.v02r01.nc")
 
-    for input_file in [gpmir_file, gridsat_file]:
+    for input_file in [cpcir_file, gridsat_file]:
         x = input_file.get_retrieval_input()
         mask = get_invalid_mask(x)
         assert np.any(~mask)


### PR DESCRIPTION
Aims to make the naming of the two geo datasets clearer and more consistent. The NCEP/CPC 4km IR data is now referred to as ``CPCIR`` instead of ``GPMIR`` to make the original source of the data clearer. For the GridSat B1 data, the b1 is now consistently dropped everywhere in the code.