### PR TITLE
Add missing value for type specifier

### DIFF
--- a/ccic/bin/train.py
+++ b/ccic/bin/train.py
@@ -146,7 +146,10 @@ def run(args):
 
     training_data = Path(args.training_data)
     if not training_data.exists():
-        LOGGER.error("Provided training data path '%s' doesn't exist.")
+        LOGGER.error(
+            "Provided training data path '%s' doesn't exist.",
+            training_data.as_posix()
+        )
         sys.exit()
 
     training_data = CCICDataset(training_data)
@@ -164,7 +167,10 @@ def run(args):
     if validation_data is not None:
         validation_data = Path(validation_data)
         if not validation_data.exists():
-            LOGGER.error("Provided validation data path '%s' doesn't exist.")
+            LOGGER.error(
+                "Provided validation data path '%s' doesn't exist.",
+                validation_data.as_posix()
+            )
             sys.exit()
         validation_data = CCICDataset(validation_data)
         validation_loader = DataLoader(

--- a/ccic/data/__init__.py
+++ b/ccic/data/__init__.py
@@ -49,7 +49,8 @@ def get_file(provider, product, path, filename, retries):
 
     if failed:
         raise RuntimeError(
-            "Downloading of file '%s' failed after three retries."
+            "Downloading of file '%s' failed after three retries.",
+            filename
         )
 
     new_file = product(local_file)


### PR DESCRIPTION
Adds missing values for type specifiers, to avoid log messages such as
```
/ccic/ccic/data/_init__.py (ERROR) :: Downloading of file '%s' failed after three retries
```