### PR TITLE
Test command

### DIFF
--- a/ccic/bin/__init__.py
+++ b/ccic/bin/__init__.py
@@ -21,6 +21,7 @@ def ccic():
     from ccic.bin import train
     from ccic.bin import process
     from ccic.bin import extract_training_data
+    from ccic.bin import test
 
     warnings.filterwarnings("ignore", category=RuntimeWarning)
 
@@ -32,6 +33,7 @@ def ccic():
     train.add_parser(subparsers)
     process.add_parser(subparsers)
     extract_training_data.add_parser(subparsers)
+    test.add_parser(subparsers)
 
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
@@ -39,3 +41,6 @@ def ccic():
 
     args = parser.parse_args()
     args.func(args)
+
+if __name__ == '__main__':
+    ccic()

--- a/ccic/bin/test.py
+++ b/ccic/bin/test.py
@@ -1,0 +1,132 @@
+# TODO: Clean up imports
+import logging
+from pathlib import Path
+import sys
+import datetime
+
+from quantnn.mrnn import MRNN
+
+from ccic.data.cpcir import CPCIR
+from ccic.data.gridsat import GridSat
+from ccic.data.training_data import CCICDataset
+from ccic.processing import get_input_files
+from torch.utils.data import DataLoader
+from ccic.processing import process_input
+import tqdm
+import torch
+from ccic.data.training_data import MASK_VALUE
+
+
+def add_parser(subparsers):
+    """
+    Add parser for 'test' command to top-level parser. This function
+    is called from the top-level parser defined in 'ccic.bin'.
+
+    Args:
+        subparsers: The subparsers object provided by the top-level parser.
+    """
+    parser = subparsers.add_parser(
+        "test",
+        help="Test the network.",
+        description=(
+            """
+            Test the network.
+            """
+        ),
+    )
+    parser.add_argument(
+        "test_data",
+        metavar="test_data",
+        type=str,
+        help="Folder containing the test data.",
+    )
+    parser.add_argument(
+        "model_path",
+        metavar="model_path",
+        type=str,
+        help="Path to the trained model.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        metavar="N",
+        type=int,
+        default=4,
+        help="The batch size to use.",
+    )
+    parser.add_argument(
+        "--accelerator",
+        metavar="device",
+        type=str,
+        default="gpu",
+        help="The accelerator to use for inference.",
+    )
+    parser.add_argument(
+        "--name",
+        metavar="name",
+        type=str,
+        default=__name__,
+        help="Name to use for logging.",
+    )
+    parser.set_defaults(func=run)
+
+def run(args):
+    """
+    Run test of the network.
+
+    Args:
+        args: The namespace object provided by the top-level parser
+    """
+    # Create logger
+    LOGGER = logging.getLogger(args.name)
+
+    test_data = Path(args.test_data)
+    if not test_data.exists():
+        LOGGER.error(
+            "Provided test data path '%s' does not exist.",
+            test_data.as_posix()
+        )
+        sys.exit()
+    
+    test_data = CCICDataset(test_data, all_channels=True, inference=True)
+    test_loader = DataLoader(
+        test_data,
+        batch_size=args.batch_size,
+        num_workers=8,
+        #worker_init_fn=test_data.seed # Commented out for reproducibility
+        shuffle=False,
+        pin_memory=True
+    )
+
+    # Load model
+    model_path = Path(args.model_path)
+    if not model_path.exists():
+        LOGGER.error("The provides model '%s' does not exist.", model_path.name)
+        return 1
+    mrnn = MRNN.load(model_path)
+
+    # Set evaluation mode
+    mrnn.model.eval()
+    with torch.no_grad():
+        for x, y in tqdm.tqdm(test_loader, ncols=80):
+            # Inference
+            # y_hat = mrnn.model(x)
+            #
+            # Pick idxs for valid values (discards corrupt input data by modification in CCICDataset)
+            # idx_valid = torch.where((y['tiwp'] > MASK_VALUE) & (x > MASK_VALUE))
+            # 
+            # filter data
+            # y = {key: values[idx_valid] for key, values in y}
+            # y_hat = {key: values[idx_valid] for key, values in y_hat}
+            #
+            # Save each pair of tensors to disk (probably provide argument)
+            # Read (1)
+
+            pass
+
+# (1)
+# `x` in line 110 could be omitted and rather do inference using ccic.processing.process_input_file
+# to match the processing chain, as well as to easily save the predictions
+# 
+# However this implies fixing or supporting (if cpcir file, but same for gridsat)
+# ccic.data.cpcir:242 as the time variable is a scalar and not a numpy array in the files we prepared
+# [the source (CPCIR) files are 1-D array]

--- a/ccic/bin/train.py
+++ b/ccic/bin/train.py
@@ -193,9 +193,9 @@ def run(args):
     model_path = Path(args.model_path)
 
     transformations = {
-        "iwc": transformations.LogLinear(),
-        "iwp": transformations.LogLinear(),
-        "iwp_rand": transformations.LogLinear(),
+        "tiwc": transformations.LogLinear(),
+        "tiwp": transformations.LogLinear(),
+        "tiwp_fpavg": transformations.LogLinear(),
         "cloud_mask": None,
         "cloud_class": None
     }
@@ -207,9 +207,9 @@ def run(args):
     quantiles_iwc[-1] = 1 - 1e-3
 
     losses = {
-        "iwp": Quantiles(quantiles_iwp, sparse=True),
-        "iwp_rand": Quantiles(quantiles_iwp, sparse=True),
-        "iwc": Quantiles(quantiles_iwc, sparse=True),
+        "tiwp": Quantiles(quantiles_iwp, sparse=True),
+        "tiwp_fpavg": Quantiles(quantiles_iwp, sparse=True),
+        "tiwc": Quantiles(quantiles_iwc, sparse=True),
         "cloud_mask": Classification(2, sparse=True),
         "cloud_class": Classification(9, sparse=True),
     }
@@ -247,7 +247,7 @@ def run(args):
         callbacks=[LearningRateMonitor()],
         strategy="ddp",
         replace_sampler_ddp=True,
-        enable_checkpointing=False
+        enable_checkpointing=False,
     )
     trainer.fit(
         model=lm, train_dataloaders=training_loader, val_dataloaders=validation_loader

--- a/ccic/data/training_data.py
+++ b/ccic/data/training_data.py
@@ -164,16 +164,19 @@ class CCICDataset:
     """
     PyTorch dataset class to load the CCIC training data.
     """
-    def __init__(self, path, input_size=None, all_channels=False):
+    def __init__(self, path, input_size=None, all_channels=False, inference=False):
         """
         Args:
             path: Path to the folder containing the training samples.
             input_size: The size of the input observations.
+            all_channels: Use all input channels (includes visible)
+            inference: to set to True when testing phase
         """
         self.path = Path(path)
         self.input_size = input_size
         self.all_channels = all_channels
         self.files = np.array(list(self.path.glob("**/cloudsat_match*.nc")))
+        self.inference = inference
         seed = int.from_bytes(os.urandom(4), "big") + os.getpid()
         self.rng = np.random.default_rng(seed)
 
@@ -266,7 +269,9 @@ class CCICDataset:
             input_size = self.input_size
             if input_size is None:
                 input_size = 256
-            x, y = apply_transformations(x, y, self.rng, input_size=input_size)
+            
+            if not self.inference:
+                x, y = apply_transformations(x, y, self.rng, input_size=input_size)
 
             # Ensure there's a minimum of valid training data in the sample.
             valid_output = (y["tiwp"] >= 0.0).sum()
@@ -277,8 +282,13 @@ class CCICDataset:
 
 
             if (valid_output < 50) or (valid_input < 50):
-                new_index = self.rng.integers(0, len(self))
-                return self[new_index]
+                if not self.inference:
+                    new_index = self.rng.integers(0, len(self))
+                    return self[new_index]
+                else:
+                    # Replace inputs and outputs with invalid values to flag it
+                    y["twip"] = torch.full_like(y["twip"], MASK_VALUE)
+                    x = torch.full_like(x, MASK_VALUE)
 
             return x, y
 

--- a/ccic/data/training_data.py
+++ b/ccic/data/training_data.py
@@ -12,12 +12,18 @@ from quantnn.normalizer import MinMaxNormalizer
 import torch
 import xarray as xr
 
+import torchvision.transforms.functional as tf
 
-NORMALIZER = MinMaxNormalizer(np.ones((3, 1, 1)), feature_axis=0)
-NORMALIZER.stats = {
+
+NORMALIZER_ALL = MinMaxNormalizer(np.ones((3, 1, 1)), feature_axis=0)
+NORMALIZER_ALL.stats = {
     0: (0.0, 1.0),
     1: (170, 310),
     2: (170, 310),
+}
+NORMALIZER = MinMaxNormalizer(np.ones((2, 1, 1)), feature_axis=0)
+NORMALIZER.stats = {
+    0: (170, 310),
 }
 
 MASK_VALUE = -100
@@ -102,36 +108,53 @@ def load_output_data(dataset, name, low=None, high=None, rng=None):
     return exp
 
 
-def apply_transformations(x, y, rng):
+def apply_transformations(x, y, rng, input_size=256):
     """
-    Randomly applies transpose and flip transformations to input.
+    Applies random transformation to the input data and extracts image samples
+    of the given size.
 
     Args:
         x: Tensor containing the input from a single training sample.
         y: Dict containing the corresponding training output.
         rng: Numpy RNG object to use for generation of random numbers.
+        input_size: The size of the input. If this is smaller than the input image
+            a random crop will be extracted from the input.
+
+    Return:
+       A tuple ``(x, y)`` containing the network input ``x`` and corresponding retrieval
+       output ``y``.
     """
-    # Transpose
-    transpose = rng.random() > 0.5
-    flip_v = rng.random() > 0.5
+    # Random rotation
+    angle = rng.uniform(0, 360)
     flip_h = rng.random() > 0.5
+
     flip_dims = []
-    if flip_v:
-        flip_dims.append(-2)
     if flip_h:
         flip_dims.append(-1)
 
-    if transpose:
-        x = torch.transpose(x, -2, -1)
+    left = (x.shape[-2] // 2) - 128
+    top = (x.shape[-2] // 2) - 128
+    shift_h = int(rng.uniform(-7, 7))
+    left += shift_h
+    shift_v = int(rng.uniform(-7, 7))
+    top += shift_v
+    top = max(top, 0)
+    left = max(left, 0)
+
+    x = tf.rotate(x, angle)
     if len(flip_dims) > 0:
         x = torch.flip(x, flip_dims)
+    x = tf.crop(x, top, left, input_size, input_size)
 
     for key in y:
         y_k = y[key]
-        if transpose:
-            y_k = torch.transpose(y_k, -2, -1)
+        if (y_k.ndim < 3):
+            y_k = tf.rotate(y_k[None], angle)[0]
+        else:
+            y_k = tf.rotate(y_k, angle)
         if len(flip_dims) > 0:
             y_k = torch.flip(y_k, flip_dims)
+        y_k = tf.crop(y_k, top, left, input_size, input_size)
         y[key] = y_k
 
     return x, y
@@ -141,8 +164,7 @@ class CCICDataset:
     """
     PyTorch dataset class to load the CCIC training data.
     """
-
-    def __init__(self, path, input_size=None):
+    def __init__(self, path, input_size=None, all_channels=False):
         """
         Args:
             path: Path to the folder containing the training samples.
@@ -150,6 +172,7 @@ class CCICDataset:
         """
         self.path = Path(path)
         self.input_size = input_size
+        self.all_channels = all_channels
         self.files = np.array(list(self.path.glob("**/cloudsat_match*.nc")))
         seed = int.from_bytes(os.urandom(4), "big") + os.getpid()
         self.rng = np.random.default_rng(seed)
@@ -204,34 +227,59 @@ class CCICDataset:
             # Input
             #
 
-            x = np.nan * np.ones((3, height, width), dtype="float32")
-            if "vis" in data:
-                x[0] = data.vis.data
-            if "ir_wv" in data:
-                x[1] = data.ir_wv.data
-            if "ir_win" in data:
-                x[2] = data.ir_win.data
+            if self.all_channels:
+                x = np.nan * np.ones((3, height, width), dtype="float32")
+                if "vis" in data:
+                    x[0] = data.vis.data
+                if "ir_wv" in data:
+                    x[1] = data.ir_wv.data
+                if "ir_win" in data:
+                    x[2] = data.ir_win.data
+                x = torch.tensor(NORMALIZER_ALL(x))
+            else:
+                x = np.nan * np.ones((1, height, width), dtype="float32")
+                if "ir_win" in data:
+                    x[0] = data.ir_win.data
+                if "cpcir2" in filename.stem:
+                    x[0] /= 4
+                x = torch.tensor(NORMALIZER(x))
+
 
             #
             # Output
             #
-            data["iwp"] = data["iwp"] * 1e-3
-            data["iwp_rand"] = data["iwp_rand"] * 1e-3
-            iwp = load_output_data(data, "iwp", 1e-6, 1e-3, self.rng)
-            iwp_rand = load_output_data(data, "iwp_rand", 1e-6, 1e-3, self.rng)
-            iwc = load_output_data(data, "iwc", 1e-6, 1e-3, self.rng)
+            data["tiwp_fpavg"] = data["tiwp_fpavg"] * 1e-3
+            data["tiwp"] = data["tiwp"] * 1e-3
+            tiwp_fpavg = load_output_data(data, "tiwp_fpavg", 1e-6, 1e-3, self.rng)
+            tiwp = load_output_data(data, "tiwp", 1e-6, 1e-3, self.rng)
+            tiwc = load_output_data(data, "tiwc", 1e-6, 1e-3, self.rng)
             cloud_class = load_output_data(data, "cloud_class").astype(np.int64)
-            cloud_mask = (cloud_class.max(0) > 0).astype(np.int64)
+            cloud_mask = load_output_data(data, "cloud_mask").astype(np.int64)
 
-            x = torch.tensor(NORMALIZER(x))
             y = {}
-            y["iwp"] = torch.tensor(iwp.copy())
-            y["iwp_rand"] = torch.tensor(iwp_rand.copy())
-            y["iwc"] = torch.tensor(iwc.copy())
+            y["tiwp"] = torch.tensor(tiwp_fpavg.copy())
+            y["tiwp_fpavg"] = torch.tensor(tiwp.copy())
+            y["tiwc"] = torch.tensor(tiwc.copy())
             y["cloud_mask"] = torch.tensor(cloud_mask.copy())
             y["cloud_class"] = torch.tensor(cloud_class.copy())
 
-            x, y = apply_transformations(x, y, self.rng)
+            input_size = self.input_size
+            if input_size is None:
+                input_size = 256
+            x, y = apply_transformations(x, y, self.rng, input_size=input_size)
+
+            # Ensure there's a minimum of valid training data in the sample.
+            valid_output = (y["tiwp"] >= 0.0).sum()
+            valid_input = (x >= -1.4).sum()
+
+            valid_output_iwc = (y["tiwc"] >= 0.0).sum()
+            valid_output_cm = (y["cloud_mask"] >= 0.0).sum()
+
+
+            if (valid_output < 50) or (valid_input < 50):
+                new_index = self.rng.integers(0, len(self))
+                return self[new_index]
+
             return x, y
 
     def __getitem__(self, index):

--- a/test/data/test_training_data.py
+++ b/test/data/test_training_data.py
@@ -37,9 +37,9 @@ def test_load_sample():
 
         x, y = dataset[0]
 
-        assert "iwp" in y
-        assert "iwp_rand" in y
-        assert "iwc" in y
+        assert "tiwp_fpavg" in y
+        assert "tiwp" in y
+        assert "tiwc" in y
         assert "cloud_class" in y
         assert "cloud_mask" in y
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -32,12 +32,12 @@ def test_forward():
     with torch.no_grad():
         y_pred = model(x)
 
-    assert "iwc" in y_pred
-    assert y_pred["iwc"].shape[1] == 64 // 4
-    assert "iwp" in y_pred
-    assert y_pred["iwp"].shape[1] == 64
-    assert "iwp_rand" in y_pred
-    assert y_pred["iwp_rand"].shape[1] == 64
+    assert "tiwc" in y_pred
+    assert y_pred["tiwc"].shape[1] == 64 // 4
+    assert "tiwp" in y_pred
+    assert y_pred["tiwp"].shape[1] == 64
+    assert "tiwp_fpavg" in y_pred
+    assert y_pred["tiwp_fpavg"].shape[1] == 64
     assert "cloud_mask" in y_pred
     assert y_pred["cloud_mask"].shape[1] == 1
     assert "cloud_class" in y_pred


### PR DESCRIPTION
Implements the command
```
ccic test [args]
```
to perform inference on a test data set and save it to disk.

Remarks:

- Adds option to `ccic.data.training_data.CCICDataset` for inference to:
  - disable random rotations and crops
  - not return a random sample if the quality of the data does not match the criteria, but rather flag it
- Aims to disable any randomness in the loading of the data for reproducibility
- Skeleton for code not complete in https://github.com/adriaat/ccic/blob/26b17e14ee0ea2d273827dea34a3a1b474da157b/ccic/bin/test.py#L111-L132

The test `test` argument can be changed, but I couldn't come up with a better word.

This pull request is simply a draft/checkpoint which can be closed if a better approach is devised.