### PR TITLE
23 inconsistent values between netcdf and zarr formats

### DIFF
--- a/ccic/bin/process.py
+++ b/ccic/bin/process.py
@@ -80,7 +80,7 @@ def add_parser(subparsers):
         ),
     )
     parser.add_argument(
-        "--targets", metavar="target", type=str, nargs="+", default=["iwp", "iwp_rand"]
+        "--targets", metavar="target", type=str, nargs="+", default=["tiwp", "tiwp_fpavg"]
     )
     parser.add_argument(
         "--tile_size",

--- a/ccic/processing.py
+++ b/ccic/processing.py
@@ -767,13 +767,13 @@ def get_encodings_zarr(variable_names):
         },
         "cloud_prob_2d": {
             "compressor": compressor,
-            "scale_factor": 250,
+            "scale_factor": 1 / 250,
             "_FillValue": 255,
             "dtype": "uint8",
         },
         "cloud_prob_3d": {
             "compressor": compressor,
-            "scale_factor": 250,
+            "scale_factor": 1 / 250,
             "_FillValue": 255,
             "dtype": "uint8",
         },


### PR DESCRIPTION
Fixes #23 

Example using the first file produced in the MWE from #23,
```python
File ccic_cpcir_201401160200
cloud_prob_2d [0. 0. 0. ... 0. 0. 0.] # Numbers from previous compression saved as Zarr
cloud_prob_2d [0.712      0.716      0.70000005 ... 0.98       0.98800004 0.99200004] # Numbers by new compression saved as Zarr
cloud_prob_2d [0.712      0.716      0.70000005 ... 0.98       0.98800004 0.99200004] # Numbers by compressed netCDF
cloud_prob_2d [0.7119199  0.7141274  0.6981546  ... 0.9819149  0.98886466 0.9921172 ] # Numbers by uncompressed netCDF, test performed manually
cloud_prob_3d [0. 0. 0. ... 0. 0. 0.] # Numbers from previous compression saved as Zarr
cloud_prob_3d [0.024      0.136      0.14400001 ... 0.52000004 0.1        0.004     ] # Numbers by new compression saved as Zarr
cloud_prob_3d [0.024      0.136      0.14400001 ... 0.52000004 0.1        0.004     ] # Numbers by compressed netCDF
cloud_prob_3d [0.02414769 0.13563198 0.14458269 ... 0.5206181  0.09800309 0.00329918] # Numbers by uncompressed netCDF, test performed manually
```

Note that the file size increases with this change (if all targets are saved), but the corrected zarr file is still about less than a half of the compressed netCDF files.