### PR TITLE
Fix tiling bug.

### DIFF
--- a/ccic/tiler.py
+++ b/ccic/tiler.py
@@ -140,8 +140,6 @@ class Tiler:
         Return:
             Numpy array containing weights for the corresponding tile.
         """
-        sl_i, sl_j = self.get_slices(i, j)
-
         m, n = self.tile_size
         w_i = np.ones((m, n))
         if i > 0:
@@ -156,6 +154,13 @@ class Tiler:
             l_trans = trans_end - trans_start
             start = self.tile_size[0] - l_trans
             w_i[start:] = np.linspace(1, 0, l_trans)[..., np.newaxis]
+            # The transition region of the antepenultimate tile may overlap
+            # that of the last tile. In this case weight must be zeroed out.
+            if i < self.M - 2:
+                trans_start = self.i_start[i + 2]
+                diff = trans_end - trans_start
+                if diff > 0:
+                    w_i[-diff:, :] = 0.0
 
         w_j = np.ones((m, n))
         if j > 0:
@@ -170,6 +175,13 @@ class Tiler:
             l_trans = trans_end - trans_start
             start = self.tile_size[1] - l_trans
             w_j[:, start:] = np.linspace(1, 0, l_trans)[np.newaxis]
+            # The transition region of the antepenultimate tile may overlap
+            # that of the last tile. In this case weight must be zeroed out.
+            if j < self.N - 2:
+                trans_start = self.j_start[j + 2]
+                diff = trans_end - trans_start
+                if diff > 0:
+                    w_j[:, -diff:] = 0.0
 
         return w_i * w_j
 

--- a/test/test_tiler.py
+++ b/test/test_tiler.py
@@ -10,8 +10,12 @@ def test_tiler():
     """
     Ensure that tiling and reassembling a tensor conserves its content.
     """
-    x = np.arange(200).astype(np.float32)
-    y = np.arange(200).astype(np.float32)
+    # Choose tile size so that a tile of size 1 is required between
+    # first and last tile. This will cause the antepenultimate tile and
+    # last tile to overlap, which triggered a bug in a previous version
+    # of the tiler.
+    x = np.arange(128 * 2 - 32 + 1).astype(np.float32)
+    y = np.arange(128 * 2 - 32 + 1).astype(np.float32)
     xy = np.stack(np.meshgrid(x, y))
 
     tiler = Tiler(xy, tile_size=128, overlap=32)


### PR DESCRIPTION
This pull request fixes a bug in the tiler that caused erroneous interpolation when the input size was such that the last and ante-penultimate tile overlap.