### PR TITLE
Mitigate antimeridian issues

### DIFF
--- a/ccic/processing.py
+++ b/ccic/processing.py
@@ -502,7 +502,7 @@ def process_input(mrnn, x, retrieval_settings=None):
             "cloud_type",
         ]
 
-    tiler = Tiler(x, tile_size=tile_size, overlap=overlap)
+    tiler = Tiler(x, tile_size=tile_size, overlap=overlap, wrap_columns=retrieval_settings.roi is None)
     means = {}
     log_std_devs = {}
     p_non_zeros = {}

--- a/ccic/tiler.py
+++ b/ccic/tiler.py
@@ -1,5 +1,6 @@
 from math import ceil
 import numpy as np
+import torch
 
 
 def get_start_and_clips(n, tile_size, overlap, soft_end: bool=False):
@@ -111,12 +112,22 @@ class Tiler:
         if self.wrap_columns:
             if j_end > self.n:
                 # Wrap the tile around the last column
-                return np.concatenate(
-                    (
-                        self.x[..., i_start:i_end, j_start:],
-                        self.x[..., i_start:i_end, :(self.tile_size[1] - (self.n - j_start))]
-                    ),
-                    axis=-1)
+                if isinstance(self.x, np.ndarray):
+                    return np.concatenate(
+                        (
+                            self.x[..., i_start:i_end, j_start:],
+                            self.x[..., i_start:i_end, :(self.tile_size[1] - (self.n - j_start))]
+                        ),
+                        axis=-1)
+                elif isinstance(self.x, torch.Tensor):
+                    return torch.cat(
+                        (
+                            self.x[..., i_start:i_end, j_start:],
+                            self.x[..., i_start:i_end, :(self.tile_size[1] - (self.n - j_start))]
+                        ),
+                        axis=-1)
+                else:
+                    raise TypeError("Only numpy.ndarray and torch.Tensor types are supported")
         # Ordinary slicing in all other cases
         return self.x[..., i_start:i_end, j_start:j_end] 
 

--- a/ccic/tiler.py
+++ b/ccic/tiler.py
@@ -2,7 +2,7 @@ from math import ceil
 import numpy as np
 
 
-def get_start_and_clips(n, tile_size, overlap):
+def get_start_and_clips(n, tile_size, overlap, soft_end: bool=False):
     """Calculate start indices and numbers of clipped pixels for a given
     side length, tile size and overlap.
 
@@ -10,10 +10,17 @@ def get_start_and_clips(n, tile_size, overlap):
         n: The image size to tile in pixels.
         tile_size: The size of each tile
         overlap: The number of pixels of overlap.
+        soft_end: Allow the last tile to go beyond ``n``, see notes for details
 
-    Rerturn:
+    Return:
         A tuple ``(start, clip)`` containing the start indices of each tile
         and the number of pixels to clip between each neighboring tiles.
+    
+    Notes:
+        ``soft_end`` is intended to use for cylindrical wrapping of the tiles
+        along the horizontal dimension, for example, to have a tile that
+        covers the antimeridian. The handling of this special tile should be
+        done outside this function.
     """
     start = []
     clip = []
@@ -23,7 +30,10 @@ def get_start_and_clips(n, tile_size, overlap):
         if j > 0:
             clip.append(overlap // 2)
         j = j + tile_size - overlap
-    start.append(max(n - tile_size, 0))
+    if not soft_end:
+        start.append(max(n - tile_size, 0))
+    else:
+        start.append(j)
     if len(start) > 1:
         clip.append((start[-2] + tile_size - start[-1]) // 2)
     start = start
@@ -40,14 +50,17 @@ class Tiler:
         M: The number of tiles along the first image dimension (rows).
         N: The number of tiles along the second image dimension (columns).
     """
-    def __init__(self, x, tile_size=512, overlap=32):
+    def __init__(self, x, tile_size=512, overlap=32, wrap_columns=False):
         """
         Args:
-            x: List of input tensors for the hydronn retrieval.
+            x: List of input tensors for the retrieval.
             tile_size: The size of a single tile.
             overlap: The overlap between two subsequent tiles.
+            wrap_columns: Apply a circular tiling along the horizontal
+                dimension, intended to overcome issues at the antimeridian
         """
         self.x = x
+        self.wrap_columns = wrap_columns
         *_, m, n = x.shape
         self.m = m
         self.n = n
@@ -69,7 +82,9 @@ class Tiler:
         self.i_start = i_start
         self.i_clip = i_clip
 
-        j_start, j_clip = get_start_and_clips(self.n, tile_size[1], overlap)
+        # `soft_end` should be True if circular tiling is expected
+        j_start, j_clip = get_start_and_clips(self.n, tile_size[1], overlap,
+                                              soft_end=self.wrap_columns)
         self.j_start = j_start
         self.j_clip = j_clip
 
@@ -93,7 +108,17 @@ class Tiler:
         i_end = i_start + self.tile_size[0]
         j_start = self.j_start[j]
         j_end = j_start + self.tile_size[1]
-        return self.x[..., i_start:i_end, j_start:j_end]
+        if self.wrap_columns:
+            if j_end > self.n:
+                # Wrap the tile around the last column
+                return np.concatenate(
+                    (
+                        self.x[..., i_start:i_end, j_start:],
+                        self.x[..., i_start:i_end, :(self.tile_size[1] - (self.n - j_start))]
+                    ),
+                    axis=-1)
+        # Ordinary slicing in all other cases
+        return self.x[..., i_start:i_end, j_start:j_end] 
 
     def get_slices(self, i, j):
         """
@@ -124,7 +149,7 @@ class Tiler:
         if j >= self.N - 1:
             j_clip_r = self.tile_size[1]
         else:
-            j_clip_r = self.tile_size[0] - self.j_clip[j]
+            j_clip_r = self.tile_size[1] - self.j_clip[j]
         slice_j = slice(j_clip_l, j_clip_r)
 
         return (slice_i, slice_j)
@@ -175,8 +200,8 @@ class Tiler:
         if j > 0:
             trans_start = self.j_start[j]
             # Shift start to right if transition overlaps with
-            # antepenultimate tile.
-            if j > 1:
+            # antepenultimate tile and wrapping is not desired
+            if j > 1 and not self.wrap_columns:
                 trans_end_prev = self.j_start[j - 2] + self.tile_size[1]
                 trans_start = max(trans_start, trans_end_prev)
             zeros = trans_start - self.j_start[j]
@@ -185,6 +210,10 @@ class Tiler:
             l_trans = min(trans_end - trans_start, self.overlap)
             w_j[:, :zeros] = 0.0
             w_j[:, zeros:zeros + l_trans] = np.linspace(0, 1, l_trans)[np.newaxis]
+        elif self.wrap_columns:
+            trans_end = (self.j_start[-1] + self.tile_size[1]) - self.n
+            l_trans = min(trans_end, self.overlap)
+            w_j[:, :l_trans] = np.linspace(0, 1, l_trans)[np.newaxis]
 
         if j < self.N - 1:
             trans_start = self.j_start[j + 1]
@@ -200,6 +229,12 @@ class Tiler:
             start = trans_start - self.j_start[j]
             w_j[:, start: start + l_trans] = np.linspace(1, 0, l_trans)[np.newaxis]
             w_j[:, start + l_trans:] = 0.0
+        elif self.wrap_columns:
+            trans_end = self.j_start[-1] + self.tile_size[1]
+            l_trans = min(trans_end % self.n, self.overlap)
+            start = self.n - self.j_start[-1]
+            w_j[:, start:start + l_trans] = np.linspace(1, 0, l_trans)[np.newaxis]
+            w_j[:, start+l_trans:] = 0.0
 
         return w_i * w_j
 
@@ -228,11 +263,10 @@ class Tiler:
                 row_slice = slice(i_start, i_end)
                 j_start = self.j_start[j]
                 j_end = j_start + self.tile_size[1]
-                col_slice = slice(j_start, j_end)
+                # modulo self.n in case self.wrap_columns is True
+                col_slice = np.arange(j_start, j_end) % self.n
 
-                output = results[..., row_slice, col_slice]
-                weights = self.get_weights(i, j)
-                output += weights * slc
+                results[..., row_slice, col_slice] += self.get_weights(i, j)*slc
 
         return results
 

--- a/test/test_tiler.py
+++ b/test/test_tiler.py
@@ -30,6 +30,30 @@ def test_tiler():
         xy_tiled = tiler.assemble(tiles)
         assert np.all(np.isclose(xy, xy_tiled))
 
+def test_tiler_wrap_columns():
+    """
+    Ensure that tiling and reassembling a tensor conserves its content.
+    """
+    for _ in range(1000):
+        height = np.random.randint(64, 1024)
+        width = np.random.randint(64, 1024)
+        x = np.arange(width).astype(np.float32)
+        y = np.arange(height).astype(np.float32)
+        xy = np.stack(np.meshgrid(x, y))
+
+        tiler = Tiler(xy, tile_size=128, overlap=32, wrap_columns=True)
+        tiles = []
+        for row_ind in range(tiler.M):
+            row = []
+            for col_ind in range(tiler.N):
+                tile = tiler.get_tile(row_ind, col_ind)
+                assert tile.shape[1:] == (min(height, 128), min(width, 128))
+                row.append(tile)
+            tiles.append(row)
+
+        xy_tiled = tiler.assemble(tiles)
+        assert np.all(np.isclose(xy, xy_tiled))
+
 def test_calculate_padding():
     """
     Test calculation of padding.

--- a/test/test_tiler.py
+++ b/test/test_tiler.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from ccic.tiler import Tiler, calculate_padding
 
+
 def test_tiler():
     """
     Ensure that tiling and reassembling a tensor conserves its content.
@@ -30,6 +31,7 @@ def test_tiler():
         xy_tiled = tiler.assemble(tiles)
         assert np.all(np.isclose(xy, xy_tiled))
 
+
 def test_tiler_wrap_columns():
     """
     Ensure that tiling and reassembling a tensor conserves its content.
@@ -53,6 +55,7 @@ def test_tiler_wrap_columns():
 
         xy_tiled = tiler.assemble(tiles)
         assert np.all(np.isclose(xy, xy_tiled))
+
 
 def test_calculate_padding():
     """


### PR DESCRIPTION
With the current implementation of the tiler the antimeridian line can suffer from edge effects, as the tiler only averages tiles from -180º to 180º.

This addition allows for the last tile of the tiler to overlap the antimeridian, in a process that I refer to as cylindrical wrapping. This mitigates the issues at the antimeridian, although it does not necessarily eliminate all issues: an unfortunate combination of image, tile, and overlap sizes can still exhibit issues. Here's an illustration with the total IWP retrieval for `GRIDSAT-B1.2013.01.01.00.v02r01.nc`, where the issue at 180º is no longer present:

![tIWP retrievals for GRIDSAT-B1.2013.01.01.00.v02r01.nc before and afer the fix](https://user-images.githubusercontent.com/28195522/228282199-81791c85-90a1-4284-8996-91beaa8311a6.png)

Some illustrations of how this fix works for tile sizes of 512 and overlapping of 128 are given below (I think I may have missused the plotting libraries for the overlapping tiles plots with transparency, but I haven't spent much time finding with that. [Here's the notebook I used](https://gist.github.com/adriaat/221b4affe292b61420d60f3d97601743).)

![gridsat_cylindrical_wrapping](https://user-images.githubusercontent.com/28195522/228245229-433f9bd1-c863-458e-a5ce-edbec8a59735.png)

![gridsat_cylindrical_wrapping_tilesoverlap](https://user-images.githubusercontent.com/28195522/228245264-1e981d98-7233-4ea6-a528-08c923f3e331.png)

![gridsat_no_cylindrical_wrapping](https://user-images.githubusercontent.com/28195522/228245317-2bf5cf81-fede-41aa-8fe9-f24476fdff4c.png)

![gridsat_no_cylindrical_wrapping_tilesoverlap](https://user-images.githubusercontent.com/28195522/228245345-66ff802f-7860-4dbb-a2a4-52fb7087aed3.png)

![cpcir_cylindrical_wrapping](https://user-images.githubusercontent.com/28195522/228245402-b9de1321-d242-4a36-939d-78575933513f.png)

![cpcir_cylindrical_wrapping_tilesoverlap](https://user-images.githubusercontent.com/28195522/228245463-ecc4da1e-6235-45fa-98f9-f6711baab32f.png)

![cpcir_no_cylindrical_wrapping](https://user-images.githubusercontent.com/28195522/228245492-30d660cd-0a66-4117-9b69-2a19775f4327.png)

![cpcir_no_cylindrical_wrapping_tilesoverlap](https://user-images.githubusercontent.com/28195522/228245539-1574a181-b53e-4d12-87fd-453b7b164cb5.png)