### PR TITLE
Force installing specific pytorch versions

### DIFF
--- a/ccic.yml
+++ b/ccic.yml
@@ -5,13 +5,12 @@ channels:
   - defaults
 dependencies:
   - python=3.10
-  - pytorch::pytorch
-  - pytorch::torchaudio
-  - pytorch::torchvision
+  - pytorch::pytorch=1.13.1
+  - pytorch::torchaudio=0.13.1
+  - pytorch::torchvision=0.14.1
   - cudatoolkit=11.6
   - satpy
   - xarray
   - cartopy
   - pyhdf
   - scipy
-prefix: /home/simonpf/miniconda3/envs/ccic

--- a/ccic_singularity_conda.def
+++ b/ccic_singularity_conda.def
@@ -15,7 +15,7 @@ From: continuumio/miniconda3
     /opt/conda/bin/conda env create -f /ccic.yml
     echo ". /opt/conda/etc/profile.d/conda.sh" >> $SINGULARITY_ENVIRONMENT
     echo "conda activate ccic" >> $SINGULARITY_ENVIRONMENT
-    /opt/conda/envs/ccic/bin/python3 -m pip install  -U torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu116
+    /opt/conda/envs/ccic/bin/python3 -m pip install -U torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu116
 
 %runscript
 


### PR DESCRIPTION
Pytorch was updated to 2.0.0. Without this fix in the container recipe, when building a container and trying to run it with CUDA, at least with in our systems, it results with the error message
```
AssertionError: Torch not compiled with CUDA enabled
```
I also updated the conda environment file to install the same torch version, although if CUDA is to be used in the conda environment then I only found it to work after re-installing torch with
```
pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu116
```