### PR TITLE
Bayesian nomenclature

### DIFF
--- a/ccic/bin/process.py
+++ b/ccic/bin/process.py
@@ -145,12 +145,12 @@ def add_parser(subparsers):
         )
     )
     parser.add_argument(
-        "--confidence_interval",
+        "--credible_interval",
         type=float,
         default=0.9,
         help=(
-            "Width of the equal-tailed confidence interval to use to report "
-            "retrieval uncertainty of scalar retrieval targets. "
+            "Probability of the equal-tailed credible interval used to "
+            "report retrieval uncertainty of scalar retrieval targets. "
             "Must be within [0, 1]."
         )
     )
@@ -402,10 +402,10 @@ def run(args):
                 )
                 return 1
 
-        if ((args.confidence_interval < 0.0) or
-            (args.confidence_interval > 1.0)):
+        if ((args.credible_interval < 0.0) or
+            (args.credible_interval > 1.0)):
             LOGGER.error(
-                "Width of confidence interval must be within [0, 1]."
+                "Probability of credible interval must be within [0, 1]."
             )
             return 1
 
@@ -419,7 +419,7 @@ def run(args):
             output_format=OutputFormat[output_format],
             database_path=args.database_path,
             inpainted_mask=args.inpainted_mask,
-            confidence_interval=args.confidence_interval
+            credible_interval=args.credible_interval
         )
 
         # Use managed queue to pass files between download threads


### PR DESCRIPTION
Besides setting the `ci_bounds` as proper coordinates (commit 756b164b2cae1995ffe67ec846e90500aea9aa86), this pull request only changes strings and definitions to use credible intervals. In my understanding:

- _Confidence intervals_ is a frequentist concept, and is a range of values calculated from a **sample of data** that is likely to contain the **true** value of the parameter θ being estimated. Note that here it is assumed that θ has an absolute true value.
- _Credible intervals_ is a Bayesian concept, and is a range of values calculated from the **observed data**, together with the **prior** distribution, indicating the plausible values for θ.

This is rather a philosophical discussion, but I think using the Bayesian terminology makes more sense in our work if we consider it as an alternative to Bayesian retrievals.