### PR TITLE
Use credibility intervals for uncertainty quantification.

### DIFF
--- a/ccic/bin/process.py
+++ b/ccic/bin/process.py
@@ -149,8 +149,9 @@ def add_parser(subparsers):
         type=float,
         default=0.9,
         help=(
-            "Width of the confidence interval to use to report retrieval "
-            "uncertainty of scalar retrieval targets. Must be within [0, 1]."
+            "Width of the equal-tailed confidence interval to use to report "
+            "retrieval uncertainty of scalar retrieval targets. "
+            "Must be within [0, 1]."
         )
     )
     parser.set_defaults(func=run)

--- a/ccic/bin/process.py
+++ b/ccic/bin/process.py
@@ -144,6 +144,15 @@ def add_parser(subparsers):
             "the retrieved pixel is inpainted (the input data was NaN)."
         )
     )
+    parser.add_argument(
+        "--confidence_interval",
+        type=float,
+        default=0.9,
+        help=(
+            "Width of the confidence interval to use to report retrieval "
+            "uncertainty of scalar retrieval targets. Must be within [0, 1]."
+        )
+    )
     parser.set_defaults(func=run)
 
 
@@ -392,6 +401,13 @@ def run(args):
                 )
                 return 1
 
+        if ((args.confidence_interval < 0.0) or
+            (args.confidence_interval > 1.0)):
+            LOGGER.error(
+                "Width of confidence interval must be within [0, 1]."
+            )
+            return 1
+
         retrieval_settings = RetrievalSettings(
             tile_size=args.tile_size,
             overlap=args.overlap,
@@ -401,7 +417,8 @@ def run(args):
             precision=args.precision,
             output_format=OutputFormat[output_format],
             database_path=args.database_path,
-            inpainted_mask=args.inpainted_mask
+            inpainted_mask=args.inpainted_mask,
+            confidence_interval=args.confidence_interval
         )
 
         # Use managed queue to pass files between download threads

--- a/ccic/bin/process.py
+++ b/ccic/bin/process.py
@@ -48,7 +48,7 @@ def add_parser(subparsers):
     )
     parser.add_argument(
         "output",
-        metavar="ouput",
+        metavar="output",
         type=str,
         help="Folder to which to write the output.",
     )

--- a/ccic/processing.py
+++ b/ccic/processing.py
@@ -452,7 +452,7 @@ def process_regression_target(
         target: The retrieval target to process.
         means: Result dict to which to store the calculated posterior means.
         conf_ints: Result dict to which to store the lower and upper bounds of
-            the caculated confidence intervals.
+            the calculated confidence intervals.
         p_non_zeros: Result dict to which to store the calculated probability that
             the target is larger than the corresponding minimum threshold.
     """
@@ -749,7 +749,7 @@ def add_static_cf_attributes(retrieval_settings, dataset):
         dataset["tiwp"].attrs[
             "long_name"
         ] = "Vertically-integrated concentration of frozen hydrometeors"
-        dataset["tiwp"].attrs["ancillary_variables"] = "tiwp_ci_tiwp"
+        dataset["tiwp"].attrs["ancillary_variables"] = "tiwp_ci p_tiwp"
 
         dataset["tiwp_ci"].attrs[
             "long_name"

--- a/ccic/processing.py
+++ b/ccic/processing.py
@@ -651,7 +651,7 @@ def process_input(mrnn, x, retrieval_settings=None):
         smpls = tiler.assemble(p_non_zero)
         results["p_" + target] = (dims, smpls)
 
-    dims = ("time", "latitude", "longitude", "bounds")
+    dims = ("time", "latitude", "longitude", "ci_bounds")
     for target, conf_int in conf_ints.items():
         conf_int = tiler.assemble(conf_int)
         results[target + "_ci"] = (dims, np.transpose(conf_int, (0, 2, 3, 1)))
@@ -754,8 +754,8 @@ def add_static_cf_attributes(retrieval_settings, dataset):
         dataset["tiwp_ci"].attrs[
             "long_name"
         ] = (
-            f"{100 * retrieval_settings.confidence_interval:0.2f}% confidence"
-            "interval for the retrieved TIWP"
+            f"{int(100 * retrieval_settings.confidence_interval)}% confidence"
+            " interval for the retrieved TIWP"
         )
         dataset["tiwp_ci"].attrs["units"] = "kg m-2"
         dataset["p_tiwp"].attrs[
@@ -772,11 +772,11 @@ def add_static_cf_attributes(retrieval_settings, dataset):
             "ancillary_variables"
         ] = "tiwp_fpavg_ci p_tiwp_fpavg"
 
-        dataset["tiwp_ci"].attrs[
+        dataset["tiwp_fpavg_ci"].attrs[
             "long_name"
         ] = (
-            f"{100 * retrieval_settings.confidence_interval:0.2f}% confidence"
-            "interval for the retrieved footprint-averaged TIWP"
+            f"{int(100 * retrieval_settings.confidence_interval)}% confidence"
+            " interval for the retrieved footprint-averaged TIWP"
         )
         dataset["tiwp_fpavg_ci"].attrs["units"] = "kg m-2"
         dataset["p_tiwp_fpavg"].attrs[

--- a/test/test_processing.py
+++ b/test/test_processing.py
@@ -144,21 +144,21 @@ def test_processing(tmp_path):
     for input_file in [cpcir_file, gridsat_file]:
         results = process_input_file(mrnn, input_file)
         assert "tiwp" in results
-        assert "tiwp_log_std_dev" in results
+        assert "tiwp_ci" in results
         assert "p_tiwp" in results
         assert np.any(np.isfinite(results["tiwp"].data))
-        assert np.any(np.isfinite(results["tiwp_log_std_dev"].data))
+        assert np.any(np.isfinite(results["tiwp_ci"].data))
         assert np.any(np.isfinite(results["p_tiwp"].data))
 
         assert "tiwp_fpavg" in results
-        assert "tiwp_fpavg_log_std_dev" in results
+        assert "tiwp_fpavg_ci" in results
         assert "p_tiwp_fpavg" in results
         assert np.any(np.isfinite(results["tiwp_fpavg"].data))
-        assert np.any(np.isfinite(results["tiwp_fpavg_log_std_dev"].data))
+        assert np.any(np.isfinite(results["tiwp_fpavg_ci"].data))
         assert np.any(np.isfinite(results["p_tiwp_fpavg"].data))
 
         assert "tiwc" in results
-        assert "tiwc_log_std_dev" not in results
+        assert "tiwc_ci" not in results
         assert "p_tiwc" not in results
 
         assert "input_filename" in results.attrs


### PR DESCRIPTION
Replaces the old uncertainty estimation with credibility intervals. Adds an option to the `process` command that allows configuring the width of the credibility interval.