### PR TITLE
Add amsfonts to tex preamble

### DIFF
--- a/ccic/files/ccic.mplstyle
+++ b/ccic/files/ccic.mplstyle
@@ -40,4 +40,4 @@ figure.edgecolor: 0.50
 image.cmap   : cmo.ice_r
 
 text.usetex: True
-text.latex.preamble : \usepackage{amsmath}\usepackage{lmodern}\usepackage{siunitx}\usepackage{cmbright}\renewcommand*\sfdefault{cmss}\renewcommand*\ttdefault{cmtt}
+text.latex.preamble : \usepackage{amsmath}\usepackage{amsfonts}\usepackage{lmodern}\usepackage{siunitx}\usepackage{cmbright}\renewcommand*\sfdefault{cmss}\renewcommand*\ttdefault{cmtt}


### PR DESCRIPTION
Some common tex fonts don't work in the plots, for example the use of `\mathbb{E}`. Adding `amsfonts` to the preamble fixes this.