### PR TITLE
Bayesian nomenclature

### DIFF
--- a/ccic/bin/process.py
+++ b/ccic/bin/process.py
@@ -145,12 +145,12 @@ def add_parser(subparsers):
         )
     )
     parser.add_argument(
-        "--confidence_interval",
+        "--credible_interval",
         type=float,
         default=0.9,
         help=(
-            "Width of the equal-tailed confidence interval to use to report "
-            "retrieval uncertainty of scalar retrieval targets. "
+            "Probability of the equal-tailed credible interval used to "
+            "report retrieval uncertainty of scalar retrieval targets. "
             "Must be within [0, 1]."
         )
     )
@@ -402,10 +402,10 @@ def run(args):
                 )
                 return 1
 
-        if ((args.confidence_interval < 0.0) or
-            (args.confidence_interval > 1.0)):
+        if ((args.credible_interval < 0.0) or
+            (args.credible_interval > 1.0)):
             LOGGER.error(
-                "Width of confidence interval must be within [0, 1]."
+                "Probability of credible interval must be within [0, 1]."
             )
             return 1
 
@@ -419,7 +419,7 @@ def run(args):
             output_format=OutputFormat[output_format],
             database_path=args.database_path,
             inpainted_mask=args.inpainted_mask,
-            confidence_interval=args.confidence_interval
+            credible_interval=args.credible_interval
         )
 
         # Use managed queue to pass files between download threads


### PR DESCRIPTION
These changes, which are consistent with the manuscript, had already made it to `main`, but a PR or a force push reverted them for convenience. This PR restores the changes, which also set coordinates for the CI bounds: the files currently generated do not indicate whether the default quantile levels or other levels are used.