### PR TITLE
Packaging

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -22,6 +22,6 @@ jobs:
         shell: bash -l {0}
         run: mamba env create --quiet --file ccic.yml &&
              conda activate ccic &&
-             pip install -e . &&
+             pip install -e .[complete] &&
              pip install pytest &&
              pytest test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: release
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  release_job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 'main'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - run: pip install .
+      - run: pip install wheel twine
+      - run: python setup.py sdist bdist_wheel
+      - run: python -m twine upload -u __token__ -p ${{ secrets.TWINE_TOKEN }} dist/*

--- a/README.md
+++ b/README.md
@@ -4,36 +4,41 @@ This repository contains the all source code for the training and
 processing of the retrieval underlying Chalmers
 Cloud Ice Climatology (CCIC) retrieval and data records.
 
+If you only need to install the `ccic` package to read CCIC data follow the minimal installation below.
+
 ## Installation
 
-The currently recommended way to install CCIC is by cloning the source code,
-creating a CCIC conda environment and the installing the package using ``pip``.
+Currently it is recommended to install the ccic package using `pip`.
 
-### Obtain the source code
+### Minimal installation (to read CCIC data)
 
-Clone the git repository to obtain the CCIC source code.
-
-``` shell
-git clone https://github.com/see-geo/ccic
-cd ccic
+```shell
+pip install git+https://github.com/SEE-GEO/ccic.git
 ```
 
-### Create conda environment
+### Advanced installation (to run retrievals)
 
-Create the ``ccic`` conda environment defined in ``ccic.yml``. The conda environment contains all of CCIC's depencies.
+1. Clone the source code
 
-``` shell
-conda env create -f ccic.yml
-conda activate ccic
-```
+    ``` shell
+    git clone https://github.com/SEE-GEO/ccic
+    cd ccic
+    ```
 
-### Install package
+2. Create a conda environment using [``ccic.yml``](ccic.yml)
 
-Finally, install the ``ccic`` Python package using ``pip``. This will also install the ``ccic`` command, which can be used to run the retrieval.
+   ```shell
+   conda env create -f ccic.yml
+   conda activate ccic
+   ```
 
-``` shell
-pip install .
-```
+3. Install ``ccic`` with the `[complete]` option.
+
+    ``` shell
+    pip install .[complete]
+    ```
+
+    If you want to be able to use any updates without re-installing ``ccic`` or you are planning to contribute, use instead `pip install -e .[complete]`.
 
 ## Running retrievals
 
@@ -45,7 +50,7 @@ Download the CCIC neural network model from [Zenodo](https://zenodo.org/record/8
 
 ### Running the retrieval
 
-The following command can then be used to run the retrieval for all available input files from 2020-01-01 00:00:00 UTC to 2020-01-01 01:00:00.
+The following command can then be used to run the retrieval for all available GridSat files from 2020-01-01 00:00:00 UTC to 2020-01-01 01:00:00 UTC.
 
 ``` shell
 ccic process ccic.pckl gridsat results 2020-01-01T00:00:00 2020-01-01T00:00:00 --targets tiwp tiwc cloud_prob_2d cloud_prob_3d 
@@ -60,7 +65,7 @@ ccic process --help
 
 ### Setup ``pansat``
 
-``ccic`` relies on the ``pansat`` package to outmatically download reuqired input data. To automatically download the CPCIR input data, you need to provide ``pansat`` with your credentials for the NASA GES DISC server.
+``ccic`` relies on the [``pansat``](https://github.com/SEE-GEO/pansat) package to autmatically download required input data. To automatically download the CPCIR input data, you need to provide ``pansat`` with your credentials for the NASA GES DISC server.
 
 
 > NOTE: We recommend creating a new account with throw-away credential for this purpose.
@@ -73,4 +78,4 @@ pansat --add "GES DISC" <username>
 
 Pansat will then first prompt you to setup a password for ``pansat``. ``pansat`` will use this password to encrypt the loging data it stores for different data portals. Following this, it will query your password for the NASA GES DISC server. After setting up ``pansat`` like this, you should be able to run the ``ccic process`` command for CPCIR input data by simply replacing the ``gridsat`` argument with ``cpcir``.
 
-
+GridSat data does not require any credentials.

--- a/ccic_singularity.def
+++ b/ccic_singularity.def
@@ -14,7 +14,7 @@ From: ccic_conda.sif
 %post
     /opt/conda/envs/ccic/bin/python3 -m pip install --no-cache-dir /pansat
     /opt/conda/envs/ccic/bin/python3 -m pip install quantnn
-    /opt/conda/envs/ccic/bin/python3 -m pip install --no-cache-dir /ccic
+    /opt/conda/envs/ccic/bin/python3 -m pip install --no-cache-dir /ccic[complete]
     /opt/conda/envs/ccic/bin/python3 -m pip install notebook tensorboard
 
     echo ". /singularity_shell_init.sh" >> $SINGULARITY_ENVIRONMENT

--- a/setup.py
+++ b/setup.py
@@ -48,20 +48,23 @@ setup(
     author="Simon Pfreundschuh",
     author_email="simon.pfreundschuh@chalmers.se",
     install_requires=[
-        "metpy",
-        "numpy",
-        "quantnn>=0.0.5",
-        "torch",
-        "pytorch-lightning",
-        "pansat",
-        "xarray",
         "zarr",
-        "netCDF4",
-        "dask",
-        "beautifulsoup4",
-        "lxml",
-        "artssat @ git+https://github.com/simonpf/artssat.git"
     ],
+    extras_require={
+        "complete": [
+            "metpy",
+            "numpy",
+            "quantnn>=0.0.5", "torch",
+            "pytorch-lightning",
+            "pansat",
+            "xarray",
+            "netCDF4",
+            "dask",
+            "beautifulsoup4",
+            "lxml",
+            "artssat @ git+https://github.com/simonpf/artssat.git"
+        ]
+    },
     packages=find_packages(),
     python_requires=">=3.8",
     project_urls={


### PR DESCRIPTION
Moves dependencies that are required for ccic processing or development into an extra called ``complete``. With this a simple ``pip install ccic`` will install only dependencies required to read ``ccic`` files.