### PR TITLE
Handle and clean up files that cannot be opened.

### DIFF
--- a/ccic/bin/process.py
+++ b/ccic/bin/process.py
@@ -322,6 +322,10 @@ def download_files(download_queue, processing_queue, retrieval_settings):
                     "Downloading of input file '%s' failed.",
                     input_file.filename
                 )
+                continue
+            if input_file is None:
+                # Something went wrong when opening the file
+                continue
         processing_queue.put((input_file, clean_up))
 
     processing_queue.put(None)

--- a/ccic/bin/process.py
+++ b/ccic/bin/process.py
@@ -433,7 +433,6 @@ def run(args):
     database_path = args.database_path
     if database_path is not None:
         database_path = Path(database_path)
-        database_path.is_dir() and database_path.exists()
         if database_path.is_dir() and database_path.exists():
             command_hash = hash(
                 f"{args.model}{args.input_type}{args.start_time}{args.end_time}"
@@ -476,26 +475,36 @@ def run(args):
             )
             failed_files = []
         else:
+            processed_files = [
+                RemoteFile(input_cls, name, working_dir=Path(working_dir))
+                for name in ProcessingLog.get_input_file(database_path, success=True)
+            ]
             failed_files = [
                 RemoteFile(input_cls, name, working_dir=Path(working_dir))
-                for name in ProcessingLog.get_failed(database_path)
+                for name in ProcessingLog.get_input_file(database_path, success=False)
             ]
-
+        
+        processed_files = set(processed_files)
         failed_files = set(failed_files)
         input_files = set(input_files)
 
+        processed = input_files.intersection(processed_files)
         failed = input_files.intersection(failed_files)
-        new_files = input_files.difference(failed_files)
+        new_files = input_files.difference(processed).difference(failed_files)
 
         # Initialize database with files that weren't in DB.
         for input_file in new_files:
             ProcessingLog(database_path, input_file)
 
         input_files = list(failed) + list(new_files)
-        LOGGER.info(
-            f"Found {len(failed)} failed input files in logging database "
-            f" {database_path}. {len(new_files)} were not yet in the database."
+        message = (
+            f"Found {len(failed)} failed input files "
+            f"in logging database {database_path}."
         )
+        if len(new_files) > 0:
+            message = f"{message} {len(new_files)} were not yet in the database."
+        
+        LOGGER.info(message)
     else:
         # Initialize database with all found files.
         if database_path is not None:

--- a/ccic/processing.py
+++ b/ccic/processing.py
@@ -103,17 +103,29 @@ class RemoteFile:
             )
 
         output_path = Path(working_dir) / self.filename
+        result = None
         if output_path.exists():
-            return self.file_cls(output_path), False
-
-        # Check if file is pre-fetched.
-        if self.prefetch_task is not None:
+            # If file is in disk
+            try:
+                result = self.file_cls(output_path)
+            except:
+                output_path.unlink(missing_ok=True)
+        elif self.prefetch_task is not None:
+            # Check if file is pre-fetched
             self.prefetch_task.result()
-            result = self.file_cls(output_path)
-            return result, False
-
-        self.file_cls.download(self.filename, output_path)
-        return self.file_cls(output_path), False
+            try:
+                result = self.file_cls(output_path)
+            except:
+                output_path.unlink(missing_ok=True)
+        else:
+            # Download file
+            self.file_cls.download(self.filename, output_path)
+            try:
+                result = self.file_cls(output_path)
+            except:
+                output_path.unlink(missing_ok=True)
+        
+        return result, False
 
 
 class OutputFormat(Enum):


### PR DESCRIPTION
A batch processing can halt if, for any reason, the input file cannot be opened. An example is that the file is present in `--input_path` but it is corrupt.

This PR addresses this issue.