### PR TITLE
Tweaks for monthly mean calculation.

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -23,5 +23,6 @@ jobs:
         run: mamba env create --quiet --file ccic.yml &&
              conda activate ccic &&
              pip install -e .[complete] &&
+             pip install git+ssh://git@github.com/simonpf/artssat &&
              pip install pytest &&
              pytest test

--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -23,6 +23,6 @@ jobs:
         run: mamba env create --quiet --file ccic.yml &&
              conda activate ccic &&
              pip install -e .[complete] &&
-             pip install git+ssh://git@github.com/simonpf/artssat &&
+             pip install git+https://github.com/simonpf/artssat.git &&
              pip install pytest &&
              pytest test

--- a/scripts/test/make_test_files.py
+++ b/scripts/test/make_test_files.py
@@ -1,0 +1,44 @@
+"""
+This script creates test data for the calculation of the monthly means.
+All 2D times are filled with the value corresponding to the hour of
+the day, so the monthly means should reproduce this value.
+"""
+from pathlib import Path
+import numpy as np
+import xarray as xr
+
+output_folder = Path("gridsat_test")
+start = np.datetime64("2020-01-01T00:00:00")
+end = np.datetime64("2020-02-01T00:00:00")
+times = xr.DataArray(np.arange(start, end, np.timedelta64(3, "h")))
+n_lats = 180
+n_lons = 360
+
+for ind in range(times.size):
+    year = times.dt.year[ind].data
+    month = times.dt.month[ind].data
+    day = times.dt.day[ind].data
+    hour = times.dt.hour[ind].data
+    filename = f"ccic_gridsat_{year:04}{month:02}{day:02}{hour:02}00.nc"
+    dims = ("time", "latitude", "longitude")
+    data = xr.Dataset({
+        "latitude": (("latitude",), np.linspace(-60, 60, n_lats)),
+        "longitude": (("longitude",), np.linspace(-180, 180, n_lons)),
+        "time": (("time",), [times[ind].data]),
+        "ci_bounds": (("ci_bounds",), np.array([0.05, 0.95])),
+        "cloud_prob_2d": (dims, hour * np.ones((1, n_lats, n_lons))),
+        "inpainted": (dims, np.ones((1, n_lats, n_lons))),
+        "p_tiwp": (dims, hour / 24 * np.ones((1, n_lats, n_lons))),
+        "tiwp": (dims, hour * np.ones((1, n_lats, n_lons))),
+        "tiwp_ci": (dims + ("ci_bounds",), hour  * np.ones((1, n_lats, n_lons, 2))),
+    })
+
+    # Mask a quarter of all values.
+    mask = np.random.rand(n_lats, n_lons) > 0.75
+    data["tiwp"].data[:, mask] = np.nan
+    data["cloud_prob_2d"].data[:, mask] = np.nan
+
+    for var in data.variables:
+        data[var].attrs["long_name"] = "long_name"
+
+    data.to_netcdf(output_folder / filename)


### PR DESCRIPTION
Modifications to the monthly mean calculation to speed up the processing on sun.

Main changes:
   - Use glob instead of rglob: Recursive glob can take a long time in a directory containing many .zarr files because each zarr file is itself a directory.
   - Sparse accumulation: Reindexing files to the all time steps of the day is slow and requires a lot of memory. Replaced it wich accumulation that uses only the corresponding time steps.
   - Data types: Use single precision for accumulation, which I think should be sufficient. However, probably better to make this a flag to allow checking its impact.
   - Add option to parallelize processing of multiple months.

The changes took the processing time for a single month down from about 20 to 10 minutes on sun. Moreover, the reduced memory requirements allow running about 8 processes in parallel.