### PR TITLE
Added xarray to dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "dask",
         "beautifulsoup4",
         "lxml",
+        "xarray",
     ],
     extras_require={
         "complete": [


### PR DESCRIPTION
Since all instructions use xarray to load CCIC data, it seems sensible to include it in the base requirements.