### PR TITLE
Script for compressing input data for archiving

### DIFF
--- a/scripts/compress_input.py
+++ b/scripts/compress_input.py
@@ -1,3 +1,15 @@
+"""
+This script is intended to compress input files
+using the zlib option with maximum compression
+when saving an xarray to a netCDF.
+
+Using this compression saves a great amount of space.
+
+The script is somewhat complicated, but it is designed
+to match the characteristics of the computer system on
+which it is meant to be executed.
+"""
+
 import argparse
 from concurrent.futures import ProcessPoolExecutor
 import datetime

--- a/scripts/compress_input.py
+++ b/scripts/compress_input.py
@@ -136,6 +136,7 @@ def wrapper(f: Path) -> None:
             # This should be faster
             with tempfile.TemporaryDirectory() as tmpdir:
                 tmp_fpath = Path(tmpdir) / f.name
+                # Saving to netCDF with compression is what takes more time
                 ds.to_netcdf(
                     tmp_fpath,
                     encoding={

--- a/scripts/compress_input.py
+++ b/scripts/compress_input.py
@@ -1,0 +1,150 @@
+import argparse
+from concurrent.futures import ProcessPoolExecutor
+import datetime
+import logging
+import multiprocessing
+from pathlib import Path
+import tempfile
+
+# `h5netcdf`is the engine used to read files remotely,
+# by importing it we assert that it is installed, even
+# if it is not explicitly used
+import h5netcdf
+from paramiko.config import SSHConfig
+from sshfs import SSHFileSystem
+import tqdm
+import xarray as xr
+
+def get_date_from_fname(fpath: Path, product: str) -> datetime.datetime:
+    stem = fpath.stem
+    return datetime.datetime.strptime(
+        stem,
+        'merg_%Y%m%d%H_4km-pixel'
+        if product == 'cpcir'
+        else 'GRIDSAT-B1.%Y.%m.%d.%H.v02r01.nc'
+    )
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '--start',
+    help=(
+        'from which date process in the '
+        'format YYYYmmdd'
+    )
+)
+parser.add_argument(
+    '--end',
+    help=(
+        'until which date process in the '
+        'format YYYYmmdd'
+    )
+)
+parser.add_argument(
+    '--source',
+    required=True,
+    type=Path,
+    help='path to the directory containing the source netCDF files'
+)
+parser.add_argument(
+    '--destination',
+    required=True,
+    type=Path,
+    help='path to the directory to place the compressed netCDF files'
+)
+parser.add_argument(
+    '--remove_source_files',
+    action='store_true',
+    help=(
+        'remove the source netCDF files after they are processed '
+        'WARNING: this is destructive'
+    )
+)
+parser.add_argument(
+    '--n',
+    default=8,
+    type=int,
+    help=(
+        'number of parallel processes '
+        '(files being compressed)'
+    )
+)
+parser.add_argument(
+    '--host',
+    type=str,
+    help=(
+        'if provided, --source and --destination '
+        'will refer to paths in this host as '
+        'configured in ~/.ssh/config (requires '
+        'passwordless ssh credential configured)'
+    )
+)
+parser.add_argument(
+    '--product',
+    default='cpcir',
+    choices=['cpcir', 'gridsat'],
+    help='input product used'
+)
+
+args = parser.parse_args()
+
+start = datetime.datetime.strptime(
+    args.start if args.start is not None else '19700101',
+    '%Y%m%d'
+)
+
+end = datetime.datetime.strptime(
+    args.end if args.end is not None else '29700101',
+    '%Y%m%d'
+)
+
+if args.host is not None:
+    sshconfig = SSHConfig.from_path(
+        Path('~/.ssh/config').expanduser()
+    ).lookup(args.host)
+    fs_ssh = SSHFileSystem(
+        sshconfig['hostname'],
+        username=sshconfig['user'],
+        client_keys=sshconfig['identityfile']
+    )
+
+extension = 'nc4' if args.product == 'cpcir' else 'nc'
+if args.host:
+    files = [Path(p) for p in fs_ssh.glob(str(args.source / f'**/*{extension}'))]
+else:
+    files = args.source.rglob(f'*{extension}')
+
+# Filter files outside [start, end)
+files = sorted([f for f in files if (start <= get_date_from_fname(f, args.product) < end)])
+
+def wrapper(f: Path) -> None:
+    try:
+        ds = xr.load_dataset(fs_ssh.open(str(f)) if args.host else f, engine='h5netcdf')
+        dst_path = args.destination / f.name
+        if args.host:
+            # If working remotely, first create the file in local disk and then send it
+            # This should be faster
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmp_fpath = Path(tmpdir) / f.name
+                ds.to_netcdf(
+                    tmp_fpath,
+                    encoding={var: {'zlib': True, 'complevel': 9} for var in ds}
+                )
+                fs_ssh.put_file(str(tmp_fpath), str(dst_path))
+        else:
+            ds.to_netcdf(
+                dst_path,
+                encoding={var: {'zlib': True, 'complevel': 9} for var in ds}
+            )
+    except Exception as e:
+        # Something should be wrong with the netCDF
+        logging.warning(f'File {f.name} -- {str(e)}')
+    finally:
+        if args.remove_source_files:
+            f.unlink()
+
+if __name__ == '__main__':
+    with ProcessPoolExecutor(
+        max_workers=args.n,
+        mp_context=multiprocessing.get_context('spawn')
+    ) as executor:
+        list(tqdm.tqdm(executor.map(wrapper, files), total=len(files), dynamic_ncols=True))

--- a/scripts/compress_input.py
+++ b/scripts/compress_input.py
@@ -3,7 +3,9 @@ This script is intended to compress input files
 using the zlib option with maximum compression
 when saving an xarray to a netCDF.
 
-Using this compression saves a great amount of space.
+Using this compression not only saves a great amount of
+disk space (can be about 25% per file) but also decreases
+the time required to read the input file (by about 10%).
 
 The script is somewhat complicated, but it is designed
 to match the characteristics of the computer system on

--- a/scripts/compress_input.py
+++ b/scripts/compress_input.py
@@ -15,136 +15,141 @@ from sshfs import SSHFileSystem
 import tqdm
 import xarray as xr
 
+
 def get_date_from_fname(fpath: Path, product: str) -> datetime.datetime:
     stem = fpath.stem
     return datetime.datetime.strptime(
         stem,
-        'merg_%Y%m%d%H_4km-pixel'
-        if product == 'cpcir'
-        else 'GRIDSAT-B1.%Y.%m.%d.%H.v02r01.nc'
+        "merg_%Y%m%d%H_4km-pixel"
+        if product == "cpcir"
+        else "GRIDSAT-B1.%Y.%m.%d.%H.v02r01.nc"
     )
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    '--start',
-    help=(
-        'from which date process in the '
-        'format YYYYmmdd'
-    )
+    "--start", help="from which date process in the format YYYYmmdd"
 )
 parser.add_argument(
-    '--end',
-    help=(
-        'until which date process in the '
-        'format YYYYmmdd'
-    )
+    "--end", help="until which date process in the format YYYYmmdd"
 )
 parser.add_argument(
-    '--source',
+    "--source",
     required=True,
     type=Path,
-    help='path to the directory containing the source netCDF files'
+    help="path to the directory containing the source netCDF files",
 )
 parser.add_argument(
-    '--destination',
+    "--destination",
     required=True,
     type=Path,
-    help='path to the directory to place the compressed netCDF files'
+    help="path to the directory to place the compressed netCDF files",
 )
 parser.add_argument(
-    '--remove_source_files',
-    action='store_true',
+    "--remove_source_files",
+    action="store_true",
     help=(
-        'remove the source netCDF files after they are processed '
-        'WARNING: this is destructive'
-    )
+        "remove the source netCDF files after they are processed "
+        "WARNING: this is destructive"
+    ),
 )
 parser.add_argument(
-    '--n',
+    "--n",
     default=8,
     type=int,
-    help=(
-        'number of parallel processes '
-        '(files being compressed)'
-    )
+    help=("number of parallel processes " "(files being compressed)"),
 )
 parser.add_argument(
-    '--host',
+    "--host",
     type=str,
     help=(
-        'if provided, --source and --destination '
-        'will refer to paths in this host as '
-        'configured in ~/.ssh/config (requires '
-        'passwordless ssh credential configured)'
-    )
+        "if provided, --source and --destination "
+        "will refer to paths in this host as "
+        "configured in ~/.ssh/config (requires "
+        "passwordless ssh credential configured)"
+    ),
 )
 parser.add_argument(
-    '--product',
-    default='cpcir',
-    choices=['cpcir', 'gridsat'],
-    help='input product used'
+    "--product",
+    default="cpcir",
+    choices=["cpcir", "gridsat"],
+    help="input product used",
 )
 
 args = parser.parse_args()
 
 start = datetime.datetime.strptime(
-    args.start if args.start is not None else '19700101',
-    '%Y%m%d'
+    args.start if args.start is not None else "19700101", "%Y%m%d"
 )
 
 end = datetime.datetime.strptime(
-    args.end if args.end is not None else '29700101',
-    '%Y%m%d'
+    args.end if args.end is not None else "29700101", "%Y%m%d"
 )
 
 if args.host is not None:
-    sshconfig = SSHConfig.from_path(
-        Path('~/.ssh/config').expanduser()
-    ).lookup(args.host)
+    sshconfig = SSHConfig.from_path(Path("~/.ssh/config").expanduser()).lookup(
+        args.host
+    )
     fs_ssh = SSHFileSystem(
-        sshconfig['hostname'],
-        username=sshconfig['user'],
-        client_keys=sshconfig['identityfile']
+        sshconfig["hostname"],
+        username=sshconfig["user"],
+        client_keys=sshconfig["identityfile"],
     )
 
-extension = 'nc4' if args.product == 'cpcir' else 'nc'
+extension = "nc4" if args.product == "cpcir" else "nc"
 if args.host:
-    files = [Path(p) for p in fs_ssh.glob(str(args.source / f'**/*{extension}'))]
+    files = [
+        Path(p) for p in fs_ssh.glob(str(args.source / f"**/*{extension}"))
+    ]
 else:
-    files = args.source.rglob(f'*{extension}')
+    files = args.source.rglob(f"*{extension}")
 
 # Filter files outside [start, end)
-files = sorted([f for f in files if (start <= get_date_from_fname(f, args.product) < end)])
+files = sorted(
+    [f for f in files if (start <= get_date_from_fname(f, args.product) < end)]
+)
+
 
 def wrapper(f: Path) -> None:
     try:
-        ds = xr.load_dataset(fs_ssh.open(str(f)) if args.host else f, engine='h5netcdf')
+        ds = xr.load_dataset(
+            fs_ssh.open(str(f)) if args.host else f, engine="h5netcdf"
+        )
         dst_path = args.destination / f.name
         if args.host:
-            # If working remotely, first create the file in local disk and then send it
+            # If working remotely,
+            # first create the file in local disk and then send it
             # This should be faster
             with tempfile.TemporaryDirectory() as tmpdir:
                 tmp_fpath = Path(tmpdir) / f.name
                 ds.to_netcdf(
                     tmp_fpath,
-                    encoding={var: {'zlib': True, 'complevel': 9} for var in ds}
+                    encoding={
+                        var: {"zlib": True, "complevel": 9} for var in ds
+                    },
                 )
                 fs_ssh.put_file(str(tmp_fpath), str(dst_path))
         else:
             ds.to_netcdf(
                 dst_path,
-                encoding={var: {'zlib': True, 'complevel': 9} for var in ds}
+                encoding={var: {"zlib": True, "complevel": 9} for var in ds},
             )
     except Exception as e:
         # Something should be wrong with the netCDF
-        logging.warning(f'File {f.name} -- {str(e)}')
+        logging.warning(f"File {f.name} -- {str(e)}")
     finally:
         if args.remove_source_files:
             f.unlink()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     with ProcessPoolExecutor(
-        max_workers=args.n,
-        mp_context=multiprocessing.get_context('spawn')
+        max_workers=args.n, mp_context=multiprocessing.get_context("spawn")
     ) as executor:
-        list(tqdm.tqdm(executor.map(wrapper, files), total=len(files), dynamic_ncols=True))
+        list(
+            tqdm.tqdm(
+                executor.map(wrapper, files),
+                total=len(files),
+                dynamic_ncols=True,
+            )
+        )


### PR DESCRIPTION
Applying compression on the CPCIR files can save not only disk space but also decrase the read time.

This is an example. A CPCIR file downloaded from the internet is
```shell
$ ls -lh merg_2013010311_4km-pixel.nc4
-rw-r--r-- 1 amell gem 34M Dec 13 18:39 merg_2013010311_4km-pixel.nc4
```
In Python, we can do:
```python
>>> import xarray as xr
>>> ds = xr.open_dataset('merg_2013010311_4km-pixel.nc4')
>>> ds.to_netcdf('merg_2013010311_4km-pixel_zlib.nc4', encoding={var: {'zlib': True, 'complevel': 9} for var in ds})
```
which results in a new file size of:
```shell
$ ls -lh merg_2013010311_4km-pixel_zlib.nc4
-rw-r--r-- 1 amell gem 25M Dec 13 18:43 merg_2013010311_4km-pixel_zlib.nc4
```
so a reduction of 25% for just using zlib with maximum compression for this particular netCDF.

Loading the netCDFs into memory for the raw and compressed netCDFs takes this much time:
```python
In [15]: %timeit _ = xr.load_dataset('merg_2013010311_4km-pixel_zlib.nc4')
614 ms ± 9.37 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
In [16]: %timeit _ = xr.load_dataset('merg_2013010311_4km-pixel.nc4')
685 ms ± 11.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
so the zlib-compressed netCDF is 10% faster for this netCDF.

This script provides a way to compress the downloaded netCDFs (intended to work for CPCIR, but should also work for GridSat), to minimize the disk space used for CPCIR data. The script is somewhat complex, since it is meant to be run in the cluster and accessing the files remotely using [fsspec's sshfs](https://github.com/fsspec/sshfs).