### PR TITLE
Add compression to monthly means

### DIFF
--- a/.github/workflows/install_and_test.yml
+++ b/.github/workflows/install_and_test.yml
@@ -28,6 +28,7 @@ jobs:
           df -h /
           conda activate ccic
           pip install -e .[complete]
+          pip install pyarts==2.4.0
           pip install git+https://github.com/simonpf/artssat.git
           pip install pytest
           pip cache purge

--- a/scripts/monthly_means.py
+++ b/scripts/monthly_means.py
@@ -222,6 +222,8 @@ def calculate_mean(current_month: datetime, status_bar: bool, precision: str) ->
     n_expected_files = n_days * (8 if args.product == 'gridsat' else 24)
     n_observed_files = len(files)
 
+    # This can fail for the first years of the data products
+    # A quick fix is to manually check the files used and use --ignore_missing_files
     if (n_observed_files != n_expected_files):
         if args.ignore_missing_files:
             logging.warning(f"Using {n_observed_files}/{n_expected_files}"

--- a/scripts/monthly_means.py
+++ b/scripts/monthly_means.py
@@ -23,9 +23,9 @@ def find_files(year: int, month: int, source: Path, product: str) -> list[Path]:
     Find the files for year `year` and month `month` at a directory.
 
     Note: it is assumed the CCIC files are stored in the following directory
-        structure: {source}/{year}/
+        structure: {source}/{product}/{year}/
     """
-    path = source / str(year)
+    path = source / product / str(year)
     files = path.glob(f'ccic_{product}_{year}{month:02d}*.*')
     return sorted(list(files))
 

--- a/scripts/monthly_means.py
+++ b/scripts/monthly_means.py
@@ -20,10 +20,13 @@ import xarray as xr
 
 def find_files(year: int, month: int, source: Path, product: str) -> list[Path]:
     """
-    Find the files for year `year` and month `month`
-    at directory `source` for product `product`.
+    Find the files for year `year` and month `month` at a directory.
+
+    Note: it is assumed the CCIC files are stored in the following directory
+        structure: {source}/{year}/
     """
-    files = source.glob(f'ccic_{product}_{year}{month:02d}*.*')
+    path = source / str(year)
+    files = path.glob(f'ccic_{product}_{year}{month:02d}*.*')
     return sorted(list(files))
 
 

--- a/scripts/monthly_means.py
+++ b/scripts/monthly_means.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 import xarray as xr
 import zarr
 
+
 def get_encodings(format: str) -> dict:
     """
     This function prepares the encodings developed for the instantaneous files
@@ -25,50 +26,47 @@ def get_encodings(format: str) -> dict:
 
     Args:
         format: either `'zarr'` or `'netcdf'`
-    
+
     Returns:
         A dictionary `encodings` to be used with
         `.to_{zarr,netcdf}('filename', encoding=encodings)`
     """
-    
-    assert format in ['zarr', 'netcdf']
+
+    assert format in ["zarr", "netcdf"]
 
     # Extract the encodings from `ccic`, which use specific key names
-    variables = ['cloud_prob_2d', 'tiwp', 'p_tiwp', 'longitude', 'latitude']
-    if format == 'zarr':
+    variables = ["cloud_prob_2d", "tiwp", "p_tiwp", "longitude", "latitude"]
+    if format == "zarr":
         encodings_ccic = get_encodings_zarr(variables)
     else:
         encodings_ccic = get_encodings_netcdf(variables)
 
     # There is no support for integer > 16
-    if format == 'zarr':
+    if format == "zarr":
         int_encoding = {
             "compressor": encodings_ccic["longitude"]["compressor"],
-            "dtype": "int16"
+            "dtype": "int16",
         }
     else:
-        int_encoding = {
-            "dtype": "int16",
-            "zlib": True
-        }
-    
-    encodings_ccic['int'] = int_encoding
+        int_encoding = {"dtype": "int16", "zlib": True}
+
+    encodings_ccic["int"] = int_encoding
 
     mapping = {
-        'cloud_prob_2d': 'cloud_prob_2d',
-        'cloud_prob_2d_stratified': 'cloud_prob_2d',
-        'cloud_prob_2d_stratified_count': 'int',
-        'inpainted': 'cloud_prob_2d', # inpainted now is in range [0, 1]
-        'inpainted_stratified': 'cloud_prob_2d',
-        'inpainted_stratified_count': 'int',
-        'p_tiwp': 'p_tiwp',
-        'p_tiwp_stratified': 'p_tiwp',
-        'p_tiwp_stratified_count': 'int',
-        'tiwp': 'tiwp',
-        'tiwp_stratified': 'tiwp',
-        'tiwp_stratified_count': 'int',
-        'longitude': 'longitude',
-        'latitude': 'latitude'
+        "cloud_prob_2d": "cloud_prob_2d",
+        "cloud_prob_2d_stratified": "cloud_prob_2d",
+        "cloud_prob_2d_stratified_count": "int",
+        "inpainted": "cloud_prob_2d",  # inpainted now is in range [0, 1]
+        "inpainted_stratified": "cloud_prob_2d",
+        "inpainted_stratified_count": "int",
+        "p_tiwp": "p_tiwp",
+        "p_tiwp_stratified": "p_tiwp",
+        "p_tiwp_stratified_count": "int",
+        "tiwp": "tiwp",
+        "tiwp_stratified": "tiwp",
+        "tiwp_stratified_count": "int",
+        "longitude": "longitude",
+        "latitude": "latitude",
     }
 
     return {k: encodings_ccic[v] for k, v in mapping.items()}
@@ -324,7 +322,7 @@ def calculate_mean(
         files, args.product, status_bar=status_bar, precision=precision
     )
 
-    if format == 'netcdf':
+    if format == "netcdf":
         fname_dst = f"ccic_{args.product}_{year}{month:02d}_monthlymean.nc"
         f_dst = args.destination / fname_dst
         logging.info(f"Writing {f_dst}")
@@ -382,7 +380,7 @@ if __name__ == "__main__":
         help=(
             "The number of processes to use for parallel processing. "
             "If '1', files will be processes sequentially."
-        )
+        ),
     )
     parser.add_argument(
         "--precision",
@@ -393,8 +391,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--format",
         type=str,
-        choices=['netcdf', 'zarr'],
-        default='netcdf',
+        choices=["netcdf", "zarr"],
+        default="netcdf",
         help="File format for the output file.",
     )
 

--- a/scripts/monthly_means.py
+++ b/scripts/monthly_means.py
@@ -331,17 +331,11 @@ if __name__ == '__main__':
             precision
         )
 
-    if n_processes == 1:
-        while current_month <= month_end:
-            calculate_mean(current_month, True, precision, args.compressed)
-            current_month += relativedelta(months=1)
-        sys.exit(0)
-
     pool = ProcessPoolExecutor(max_workers=n_processes)
     tasks = []
     months = []
     while current_month <= month_end:
-        tasks.append(pool.submit(calculate_mean, current_month, False, precision, args.compressed))
+        tasks.append(pool.submit(calculate_mean, current_month, False if n_processes > 1 else True, precision, args.compressed))
         months.append(current_month)
         current_month += relativedelta(months=1)
 

--- a/scripts/monthly_means.py
+++ b/scripts/monthly_means.py
@@ -328,15 +328,16 @@ def calculate_mean(
         fname_dst = f"ccic_{args.product}_{year}{month:02d}_monthlymean.nc"
         f_dst = args.destination / fname_dst
         logging.info(f"Writing {f_dst}")
-        ds.to_netcdf(f_dst)
+        # Use the same encodings as in ccic instantaneous files
+        encodings = get_encodings(format)
+        ds.to_netcdf(f_dst, encoding=encodings)
     else:
         fname_dst = f"ccic_{args.product}_{year}{month:02d}_monthlymean.zarr"
         f_dst = args.destination / fname_dst
         logging.info(f"Writing {f_dst}")
-        # Applying this encoding negligibly increases the write time and memorry but
-        # offers better compression ratio and read time and memory usage.
-        encoding = {var: {"compressor": zarr.Blosc("lz4", clevel=9)} for var in ds}
-        ds.to_zarr(f_dst, encoding=encoding)
+        # Use the same encodings as in ccic instantaneous files
+        encodings = get_encodings(format)
+        ds.to_zarr(f_dst, encoding=encodings)
 
 
 if __name__ == "__main__":

--- a/scripts/monthly_means.py
+++ b/scripts/monthly_means.py
@@ -11,12 +11,13 @@ import sys
 from pathlib import Path
 import warnings
 
-import ccic # Required
+import ccic  # Required
 from dateutil.relativedelta import relativedelta
 import numpy as np
 from tqdm import tqdm
 import xarray as xr
 import zarr
+
 
 def find_files(year: int, month: int, source: Path, product: str) -> list[Path]:
     """
@@ -26,15 +27,15 @@ def find_files(year: int, month: int, source: Path, product: str) -> list[Path]:
         structure: {source}/{product}/{year}/
     """
     path = source / product / str(year)
-    files = path.glob(f'ccic_{product}_{year}{month:02d}*.*')
+    files = path.glob(f"ccic_{product}_{year}{month:02d}*.*")
     return sorted(list(files))
 
 
 def process_month(
-        files: list[Path],
-        product: str,
-        status_bar: bool = True,
-        precision: str = "single"
+    files: list[Path],
+    product: str,
+    status_bar: bool = True,
+    precision: str = "single",
 ) -> xr.Dataset:
     """
     Compute the monthly means for the given month, stratified by the
@@ -48,13 +49,13 @@ def process_month(
         # using the zarr engine
         warnings.filterwarnings(
             "ignore",
-            message="('netcdf4'|'scipy'|'h5netcdf') fails while guessing"
+            message="('netcdf4'|'scipy'|'h5netcdf') fails while guessing",
         )
         ds = xr.load_dataset(files[0])
 
     # Drop credibile interval variable
-    if 'tiwp_ci' in ds:
-        ds = ds.drop_vars('tiwp_ci')
+    if "tiwp_ci" in ds:
+        ds = ds.drop_vars("tiwp_ci")
 
     # Save the original attributes for later
     attrs = ds.attrs
@@ -64,29 +65,33 @@ def process_month(
     ds.attrs = {}
 
     # Set the time dimension
-    if product == 'gridsat':
-        time_deltas = [i * np.timedelta64(3, 'h') for i in range(8)]
+    if product == "gridsat":
+        time_deltas = [i * np.timedelta64(3, "h") for i in range(8)]
     else:
-        time_deltas = [i * np.timedelta64(30, 'm') for i in range(24 * 2)]
+        time_deltas = [i * np.timedelta64(30, "m") for i in range(24 * 2)]
 
     # .astype('datetime64[M]').astype('datetime64[m]'):
     # hack to avoid dealing with days, i.e. date set to YYYYmmddT00:00
-    time_offset = ds.time.values[0].astype('datetime64[M]').astype('datetime64[m]')
+    time_offset = (
+        ds.time.values[0].astype("datetime64[M]").astype("datetime64[m]")
+    )
     time_values = np.array([time_offset + delta for delta in time_deltas])
     time_bounds = time_values[:-1] + 0.5 * (time_values[1:] - time_values[:-1])
     bnds_dtype = time_bounds.dtype
 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message=(
-            "Converting non-nanosecond precision datetime "
-            "values to nanosecond precision."
-            )
+        warnings.filterwarnings(
+            "ignore",
+            message=(
+                "Converting non-nanosecond precision datetime "
+                "values to nanosecond precision."
+            ),
         )
         # Floor day to first day of the month
-        ds['time'] = ds['time'] - np.array(
-            [np.timedelta64(d - 1, 'D') for d in ds.time.dt.day.values]
+        ds["time"] = ds["time"] - np.array(
+            [np.timedelta64(d - 1, "D") for d in ds.time.dt.day.values]
         )
-        ds = ds.reindex({'time': time_values}, method=None, fill_value=0)
+        ds = ds.reindex({"time": time_values}, method=None, fill_value=0)
 
     # Initialize all variables to zero and create a count variable
     variables = set(ds.variables) - set(ds.coords)
@@ -98,12 +103,12 @@ def process_month(
     for v in variables:
         # float instead of float32 to avoid any limitations accumulating
         # .copy to assign coordinates correctly
-        ds[v] = ds[v].copy(
-            data=np.zeros_like(ds[v]), deep=True
-        ).astype(float_type)
-        ds[f'{v}_count'] = ds[v].copy(
-            data=np.zeros_like(ds[v]), deep=True
-        ).astype(np.int16)
+        ds[v] = (
+            ds[v].copy(data=np.zeros_like(ds[v]), deep=True).astype(float_type)
+        )
+        ds[f"{v}_count"] = (
+            ds[v].copy(data=np.zeros_like(ds[v]), deep=True).astype(np.int16)
+        )
 
     # Accumulate values
     itr = files
@@ -114,40 +119,46 @@ def process_month(
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
-                message="('netcdf4'|'scipy'|'h5netcdf') fails while guessing"
+                message="('netcdf4'|'scipy'|'h5netcdf') fails while guessing",
             )
             ds_f = xr.load_dataset(path)
 
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                "ignore",
-                message=("Converting non-nanosecond precision")
+                "ignore", message=("Converting non-nanosecond precision")
             )
             # Replace the timestamps day with first day of the month
             # and reindex to handle time dimension
-            ds_f['time'] = ds_f['time'] - np.array(
-                [np.timedelta64(d - 1, 'D') for d in ds_f.time.dt.day.values]
+            ds_f["time"] = ds_f["time"] - np.array(
+                [np.timedelta64(d - 1, "D") for d in ds_f.time.dt.day.values]
             )
         time_ind = np.digitize(
             ds_f.time.data.astype(bnds_dtype).astype(np.int64),
-            time_bounds.astype(np.int64)
+            time_bounds.astype(np.int64),
         )
         for v in variables:
             is_finite = np.isfinite(ds_f[v].data)
             ds[v][{"time": time_ind}] += np.where(is_finite, ds_f[v].data, 0)
-            ds[f'{v}_count'][{"time": time_ind}] += is_finite.astype(int)
+            ds[f"{v}_count"][{"time": time_ind}] += is_finite.astype(int)
 
     # Divide by the total count
     for v in variables:
-        non_zero_count = ds[f'{v}_count'].data > 0
+        non_zero_count = ds[f"{v}_count"].data > 0
         # .copy to set dimensions correctly
-        ds[v] = ds[v].copy(
-            data=np.divide(ds[v].data, ds[f'{v}_count'].data,
-                           out=np.full_like(ds[v].data, np.nan),
-                           where=non_zero_count),
-            deep=True
-        ).astype(np.float32)
-        ds[f'{v}_count'] = ds[f'{v}_count'].astype(np.int16)
+        ds[v] = (
+            ds[v]
+            .copy(
+                data=np.divide(
+                    ds[v].data,
+                    ds[f"{v}_count"].data,
+                    out=np.full_like(ds[v].data, np.nan),
+                    where=non_zero_count,
+                ),
+                deep=True,
+            )
+            .astype(np.float32)
+        )
+        ds[f"{v}_count"] = ds[f"{v}_count"].astype(np.int16)
 
     # Update attributes
     ds.attrs = attrs
@@ -155,56 +166,65 @@ def process_month(
     ds.attrs["input_filename"] = [f.name for f in files]
     for v in variables:
         ds[v].attrs = attrs_data[v]
-        ds[f'{v}_count'].attrs['units'] = '1'
-        ds[f'{v}_count'].attrs['long_name'] = (
-            "Count of '{:}' values used "
-            "for the stratified monthly mean"
-            ).format(ds[v].attrs['long_name'])
-        ds[v].attrs['long_name'] = '{:}, stratified monthly mean'.format(
-            ds[v].attrs['long_name']
+        ds[f"{v}_count"].attrs["units"] = "1"
+        ds[f"{v}_count"].attrs["long_name"] = (
+            "Count of '{:}' values used " "for the stratified monthly mean"
+        ).format(ds[v].attrs["long_name"])
+        ds[v].attrs["long_name"] = "{:}, stratified monthly mean".format(
+            ds[v].attrs["long_name"]
         )
     for coord in ds.coords:
         ds[coord].attrs = attrs_data[coord]
 
     # Append `_stratified` the stratified variables
-    ds = ds.rename({v: f'{v}_stratified' for v in variables})
-    ds = ds.rename({f'{v}_count': f'{v}_stratified_count' for v in variables})
+    ds = ds.rename({v: f"{v}_stratified" for v in variables})
+    ds = ds.rename({f"{v}_count": f"{v}_stratified_count" for v in variables})
 
     # Compute monthly means irrespective of timestamp
     # Setting dtype='datetime64[M]' seems to not have effect
-    ds['month'] = (('month',), [ds.time.data.min()])
+    ds["month"] = (("month",), [ds.time.data.min()])
     for v in variables:
         ds[v] = (
             np.divide(
-                (ds[f'{v}_stratified'] * ds[f'{v}_stratified_count']).sum('time', skipna=True),
-                ds[f'{v}_stratified_count'].sum('time', skipna=True),
-                out=np.full_like(ds[f'{v}_stratified'].sum('time'), np.nan),
-                where=(ds[f'{v}_stratified_count'].sum('time', skipna=True).data > 0)
+                (ds[f"{v}_stratified"] * ds[f"{v}_stratified_count"]).sum(
+                    "time", skipna=True
+                ),
+                ds[f"{v}_stratified_count"].sum("time", skipna=True),
+                out=np.full_like(ds[f"{v}_stratified"].sum("time"), np.nan),
+                where=(
+                    ds[f"{v}_stratified_count"].sum("time", skipna=True).data
+                    > 0
+                ),
             )
-        ).expand_dims({'month': 1})
+        ).expand_dims({"month": 1})
 
     # Change the name and data type of variable `time`
-    ds = ds.rename({'time': 'hour_of_day'})
+    ds = ds.rename({"time": "hour_of_day"})
     with warnings.catch_warnings():
         warnings.filterwarnings(
-            "ignore",
-            message=("Converting non-nanosecond precision")
+            "ignore", message=("Converting non-nanosecond precision")
         )
-        ds['hour_of_day'] = (
-            ds.hour_of_day - ds.hour_of_day.astype('datetime64[D]').astype(ds.hour_of_day.dtype)
-        )
+        ds["hour_of_day"] = ds.hour_of_day - ds.hour_of_day.astype(
+            "datetime64[D]"
+        ).astype(ds.hour_of_day.dtype)
 
     # Set attributes for the full monthly mean data
-    attrs_data['month'] = {'long_name': 'month', 'standard_name': 'month'}
+    attrs_data["month"] = {"long_name": "month", "standard_name": "month"}
     for v in variables:
         ds[v].attrs = attrs_data[v]
-        ds[v].attrs['long_name'] = '{:}, monthly mean'.format(attrs_data[v]['long_name'])
+        ds[v].attrs["long_name"] = "{:}, monthly mean".format(
+            attrs_data[v]["long_name"]
+        )
 
     return ds
 
 
-def calculate_mean(current_month: datetime, status_bar: bool,
-                   precision: str, compress: bool=True) -> None:
+def calculate_mean(
+    current_month: datetime,
+    status_bar: bool,
+    precision: str,
+    compress: bool = True,
+) -> None:
     """
     Helper function encapsulating all processing for calculating means for
     a given month.
@@ -220,96 +240,97 @@ def calculate_mean(current_month: datetime, status_bar: bool,
     year = current_month.year
     month = current_month.month
     logging.info(f"Finding {args.product} files for {year}-{month:02d}")
-    files = find_files(year, month,
-                        args.source, args.product)
+    files = find_files(year, month, args.source, args.product)
 
     # Check that there is the expected number of files
     _, n_days = calendar.monthrange(year, month)
-    n_expected_files = n_days * (8 if args.product == 'gridsat' else 24)
+    n_expected_files = n_days * (8 if args.product == "gridsat" else 24)
     n_observed_files = len(files)
 
     # This can fail for the first years of the data products
     # A quick fix is to manually check the files used and use --ignore_missing_files
-    if (n_observed_files != n_expected_files):
+    if n_observed_files != n_expected_files:
         if args.ignore_missing_files:
-            logging.warning(f"Using {n_observed_files}/{n_expected_files}"
-                            f" retrievals to compute the means")
+            logging.warning(
+                f"Using {n_observed_files}/{n_expected_files}"
+                f" retrievals to compute the means"
+            )
         else:
-            raise ValueError(f"Expected {n_expected_files} retrievals "
-                                f"but found {n_observed_files} retrievals")
+            raise ValueError(
+                f"Expected {n_expected_files} retrievals "
+                f"but found {n_observed_files} retrievals"
+            )
     if len(files) == 0:
         logging.warning(f"No files to process for {year}-{month:02d}")
         return
 
     logging.info(f"Processing {year}-{month:02d}")
-    ds = process_month(files, args.product, status_bar=status_bar, precision=precision)
-
-    fname_dst = f'ccic_{args.product}_{year}{month:02d}_monthlymean.zarr'
-    f_dst = args.destination / fname_dst
-    logging.info(f'Writing {f_dst}')
-    # TODO: Revise compression algorithm
-    ds.to_zarr(
-        f_dst,
-        encoding={var: {"compressor": zarr.Blosc('lz4', clevel=9)} for var in ds} if compress else None
+    ds = process_month(
+        files, args.product, status_bar=status_bar, precision=precision
     )
 
-if __name__ == '__main__':
+    fname_dst = f"ccic_{args.product}_{year}{month:02d}_monthlymean.zarr"
+    f_dst = args.destination / fname_dst
+    logging.info(f"Writing {f_dst}")
+    # TODO: Revise compression algorithm
+    encoding = {var: {"compressor": zarr.Blosc("lz4", clevel=9)} for var in ds}
+    ds.to_zarr(f_dst, encoding=encoding if compress else None)
+
+
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--product',
-        choices=['gridsat', 'cpcir'],
+        "--product",
+        choices=["gridsat", "cpcir"],
         required=True,
-        help="product to process"
+        help="product to process",
     )
     parser.add_argument(
-        '--source',
+        "--source",
         type=Path,
         required=True,
-        help="directory of the CCIC data record"
+        help="directory of the CCIC data record",
     )
     parser.add_argument(
-        '--destination',
+        "--destination",
         type=Path,
         required=True,
-        help="directory to save the monthly means"
+        help="directory to save the monthly means",
     )
     parser.add_argument(
-        '--month',
-        required=True,
-        help="month to process in the format YYYYmm"
+        "--month", required=True, help="month to process in the format YYYYmm"
     )
     parser.add_argument(
-        '--month_end',
-        nargs='?',
+        "--month_end",
+        nargs="?",
         default=None,
-        help="process until this month in the format YYYYmm"
+        help="process until this month in the format YYYYmm",
     )
     parser.add_argument(
-        '--ignore_missing_files',
-        action='store_true',
-        help="ignore missing expected retrievals"
+        "--ignore_missing_files",
+        action="store_true",
+        help="ignore missing expected retrievals",
     )
+    parser.add_argument("--verbose", action="store_true", help="verbose mode")
     parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='verbose mode'
-    )
-    parser.add_argument(
-        '--n_processes',
+        "--n_processes",
         type=int,
         default=1,
-        help="The number of processes to use for parallel processing. If '1', files will be processes sequentially."
+        help=(
+            "The number of processes to use for parallel processing. "
+            "If '1', files will be processes sequentially."
+        )
     )
     parser.add_argument(
         "--precision",
         type=str,
         default="double",
-        help="Whether to use double or single precision for accumulating data."
+        help="Whether to use double or single precision for accumulating data.",
     )
     parser.add_argument(
-        '--compressed',
-        action='store_true',
-        help="Apply loseless compression to the output file"
+        "--compressed",
+        action="store_true",
+        help="Apply loseless compression to the output file.",
     )
 
     args = parser.parse_args()
@@ -320,22 +341,30 @@ if __name__ == '__main__':
     if (args.month_end is None) or args.month_end < args.month:
         args.month_end = args.month
 
-    current_month = datetime.strptime(args.month, '%Y%m')
-    month_end = datetime.strptime(args.month_end, '%Y%m')
+    current_month = datetime.strptime(args.month, "%Y%m")
+    month_end = datetime.strptime(args.month_end, "%Y%m")
     n_processes = args.n_processes
 
     precision = args.precision
     if not precision in ["single", "double"]:
         logging.error(
             "Precision should be one of ['single', 'double'] got '%s'.",
-            precision
+            precision,
         )
 
     pool = ProcessPoolExecutor(max_workers=n_processes)
     tasks = []
     months = []
     while current_month <= month_end:
-        tasks.append(pool.submit(calculate_mean, current_month, False if n_processes > 1 else True, precision, args.compressed))
+        tasks.append(
+            pool.submit(
+                calculate_mean,
+                current_month,
+                False if n_processes > 1 else True,
+                precision,
+                args.compressed,
+            )
+        )
         months.append(current_month)
         current_month += relativedelta(months=1)
 
@@ -344,6 +373,7 @@ if __name__ == '__main__':
             task.result()
             del task
         except Exception:
-            logging.exception("The following error was encountered when processing %s.", month)
+            logging.exception(
+                "The following error was encountered when processing %s.", month
+            )
     sys.exit(0)
-

--- a/scripts/monthly_means.py
+++ b/scripts/monthly_means.py
@@ -231,6 +231,9 @@ def calculate_mean(current_month: datetime, status_bar: bool, precision: str) ->
         else:
             raise ValueError(f"Expected {n_expected_files} retrievals "
                                 f"but found {n_observed_files} retrievals")
+    if len(files) == 0:
+        logging.warning(f"No files to process for {year}-{month:02d}")
+        return
 
     logging.info(f"Processing {year}-{month:02d}")
     ds = process_month(files, args.product, status_bar=status_bar, precision=precision)


### PR DESCRIPTION
This PR addresses:

- Handle multiple years in one go, following the agreed directory structure
- An option to save files with compression (using Zarr instead of netCDF), which saves both disk space and write time. This is specially relevant for CPCIR data, as the required disk space can be reduced by a factor of ~2.5, that is, going from 10.5 TB of CPCIR-CCIC monthly means to 'only' 4.2 TB.

While working in this PR I learnt and solved the following issues:

- **Problem**: Encapsulating memory-intensive operations in a function with variables not existing outside the function does not guarantee that the memory is free'd after its completion. I encountered this when running the monthly means for many months (was getting OOMs after a few iterations).
  **Solution**: call the function with a `multiprocessing.Process` or similar. Commit d46ce29b3ecf757c895a5972e850d94327b39908
  Source: https://stackoverflow.com/a/1316799
- **Problem**: unreasonable write times when using netCDF with encoding using a compression algorithm (up to almost 2 hours).
   **Solution**: The 'default' (as in the [`.to_netcdf`](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.to_netcdf.html) example) encoding can be inefficient. Using the Zarr file format (with or without compression!) can save both disk space and write times.
  Source: I went a bit far and started to benchmark the different xarray encoding options with either netCDF or Zarr formats. See the image below. There is still something that puzzles me, so I asked a question in SO to find an answer: [how can a Zarr without encoding consume less space than its actual data?](https://stackoverflow.com/q/78137651).

![Benchmark stats](https://github.com/SEE-GEO/ccic/assets/28195522/49b4f802-63bd-46fe-a0a0-075e01a9917c)

It seems that in the last few days pyarts in PyPI was 'yanked'. Without bb9efe4c44d170cba233e3f3ce83f6876e4a545c the tests fail.