### PR TITLE
Fix Read the Docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,9 +11,7 @@ build:
 
 python:
   install:
-    - method: pip
-      packages:
-        - jupyter-book
+    - requirements: docs/requirements.txt
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,13 +9,7 @@ build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.
       - "jupyter-book config sphinx docs/"
 
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-      - complete
-
 sphinx:
+  configuration: docs/conf.py
   builder: html
   fail_on_warning: false

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,12 @@ build:
       # Generate the Sphinx configuration for this Jupyter Book so it builds.
       - "jupyter-book config sphinx docs/"
 
+python:
+  install:
+    - method: pip
+      packages:
+        - jupyter-book
+
 sphinx:
   configuration: docs/conf.py
   builder: html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+jupyter-book


### PR DESCRIPTION
The current https://ccic.readthedocs.io does not reflect the content of `docs/`.

This is caused by a change in Read the Docs using Sphinx that since 2025-01-20 builds fail if they do not contain an explicit path to `docs/conf.py`, see ["deprecation of projects using Sphinx or MkDocs without an explicit configuration file"](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/).

I also took the chance to remove the complete install of ccic, https://github.com/SEE-GEO/ccic/blob/224c8fccab3d55e61a6ade77a479bdf07ba9bc80/.readthedocs.yaml#L12-L17, which is not necessary for building the docs, and only install `jupyter-book`. 